### PR TITLE
Update kendo.data.js, resolving MVVM/IE8 issue

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -1357,12 +1357,14 @@ var __meta__ = {
 
         for (idx = 0; idx < len; idx++) {
             aggr = aggregates[idx];
-            functionName = aggr.aggregate;
-            var field = aggr.field;
-            accumulator[field] = accumulator[field] || {};
-            state[field] = state[field] || {};
-            state[field][functionName] = state[field][functionName] || {};
-            accumulator[field][functionName] = functions[functionName.toLowerCase()](accumulator[field][functionName], item, kendo.accessor(field), index, length, state[field][functionName]);
+            if (aggr) {
+                functionName = aggr.aggregate;
+                var field = aggr.field;
+                accumulator[field] = accumulator[field] || {};
+                state[field] = state[field] || {};
+                state[field][functionName] = state[field][functionName] || {};
+                accumulator[field][functionName] = functions[functionName.toLowerCase()](accumulator[field][functionName], item, kendo.accessor(field), index, length, state[field][functionName]);
+            }
         }
     }
 


### PR DESCRIPTION
Added simple check to not calculate aggregate when aggr object is null/undefined/falsy. Resolves an undefined object error in IE8 using MVVM, possibly others.

Suspect this was due to IE miscalculating the Array.length property as off by one, causing the loop to touch an index that doesn't exist. 
