### PR TITLE
Drag Scrolling Kendo UI Mobile ListView throws error checking useNativeScrolling

### DIFF
--- a/src/kendo.core.js
+++ b/src/kendo.core.js
@@ -2938,7 +2938,7 @@ function pad(number, digits, end) {
 
         viewHasNativeScrolling: function() {
             var view = this.view();
-            return view && view.options.useNativeScrolling;
+            return view && (view.options ? view.options.useNativeScrolling : true);
         },
 
         container: function() {


### PR DESCRIPTION
When scrolling a Kendo UI Mobile ListView OUTSIDE of the Kendo UI Mobile Application object, the view.hasNativeScrolling check runs and the options object on the view is undefined, rendering the useNativeScrolling property check in error.

This only occurs when doing a "drag scroll" (click and hold while moving mouse) with the mouse, but occurs always on a mobile device (iOS 7.1 tested).

http://trykendoui.telerik.com/OBEw

Fix:

Check for the presence of the `options` object on the view during `viewHasNativeScrolling`.  If it isn't there, than always assume native scrolling.
