### PR TITLE
Allow defaultValue to be a function.

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -733,7 +733,13 @@ var __meta__ = {
             name = typeof (field.field) === STRING ? field.field : name;
 
             if (!field.nullable) {
-                value = proto.defaults[originalName !== name ? originalName : name] = field.defaultValue !== undefined ? field.defaultValue : defaultValues[type.toLowerCase()];
+                var defaultValueResult = defaultValues[type.toLowerCase()];
+
+                if (field.defaultValue !== undefined) {
+                    defaultValueResult = typeof field.defaultValue === "function" ? field.defaultValue() : field.defaultValue;
+                }
+
+                value = proto.defaults[originalName !== name ? originalName : name] = defaultValueResult;
             }
 
             if (options.id === name) {

--- a/tests/data/datasource/model.js
+++ b/tests/data/datasource/model.js
@@ -363,4 +363,53 @@ test("accept does not wrap field with underscore", function() {
     equal(model._foo.foo, "foo1");
 });
 
+test("defaultValue can be set to a function", function () {
+    var seed = 2;
+    var getForeignKey = function () {
+        return seed;
+    }
+
+    var dataSource = new kendo.data.DataSource({
+        data: [{ id: 1, foreignKey: 1, someOtherValue: "test" }],
+        schema: {
+            model: {
+                id: "id",
+                fields: {
+                    id: { type: "number", defaultValue: "" },
+                    foreignKey: { type: "number", defaultValue: getForeignKey },
+                    someOtherValue: { type: "string" },
+                }
+            }
+        },
+    });
+
+    dataSource.read();
+    var model = dataSource.get(1);
+
+    equal(getForeignKey(), 2);
+
+    equal(model.id, 1);
+
+    dataSource.add({
+        id: 2,
+        foreignKey: getForeignKey(),
+        someOtherValue: "test 2"
+    });
+    var model2 = dataSource.get(2);
+    equal(model2.id, 2);
+    equal(model2.foreignKey, 2);
+
+    seed++;
+
+    dataSource.add({
+        id: 3,
+        foreignKey: getForeignKey(),
+        someOtherValue: "test 2"
+    });
+
+    var model3 = dataSource.get(3);
+    equal(model3.id, 3);
+    equal(model3.foreignKey, 3);
+});
+
 }());


### PR DESCRIPTION
Solution for Issue #122.

**Why:** There are situations where a new item being added to a dataSource can have a default value that is not static. For example, if you are referencing a foreign key that has been defined elsewhere on the page and is dependent on what is happening at runtime.

**What:** Proposed solution allows for function evaluation during model initialization, in addition to using strict value types.

**How:** A slight modification of the defaultValue field to first set the defaultValue to the given internal default from the defaultValues array, then if the default value is not undefined, return the execution of the function if the default value is a function type.

NOTE: Included test cannot exactly confirm because the Grid is not a part of the Core, but it does demonstrate the logic behind the idea in a testable way. However, I have modified my own version of UI for MVC to test this scenario, and it works properly.
