### PR TITLE
Reference jQuery more consistently

### DIFF
--- a/src/kendo.core.js
+++ b/src/kendo.core.js
@@ -1,6 +1,6 @@
 (function(f, define){
-    define([], f);
-})(function(){
+    define(['jquery'], f);
+})(function(jQuery){
 
 var __meta__ = {
     id: "core",
@@ -3913,4 +3913,4 @@ function pad(number, digits, end) {
 
 return window.kendo;
 
-}, typeof define == 'function' && define.amd ? define : function(_, f){ f(); });
+}, typeof define == 'function' && define.amd ? define : function(_, f){ f(jQuery); });

--- a/src/kendo.touch.js
+++ b/src/kendo.touch.js
@@ -1,6 +1,6 @@
 (function(f, define){
-    define([ "./kendo.core", "./kendo.userevents" ], f);
-})(function(){
+    define([ "jquery", "./kendo.core", "./kendo.userevents" ], f);
+})(function(jQuery){
 
 var __meta__ = {
     id: "touch",
@@ -194,7 +194,7 @@ var __meta__ = {
     });
 
 
-    window.kendo.jQuery.fn.kendoMobileSwipe = function(callback, options) {
+    jQuery.fn.kendoMobileSwipe = function(callback, options) {
         this.each(function() {
             new Swipe(this, callback, options);
         });
@@ -205,4 +205,4 @@ var __meta__ = {
 
 return window.kendo;
 
-}, typeof define == 'function' && define.amd ? define : function(_, f){ f(); });
+}, typeof define == 'function' && define.amd ? define : function(_, f){ f(window.jQuery); });

--- a/src/kendo.touch.js
+++ b/src/kendo.touch.js
@@ -194,7 +194,7 @@ var __meta__ = {
     });
 
 
-    window.jQuery.fn.kendoMobileSwipe = function(callback, options) {
+    window.kendo.jQuery.fn.kendoMobileSwipe = function(callback, options) {
         this.each(function() {
             new Swipe(this, callback, options);
         });


### PR DESCRIPTION
When using AMD, reference jQuery using the define call to allow for jQuery.noConflict()