### PR TITLE
Update kendo.dropdownlist.js

### DIFF
--- a/src/kendo.dropdownlist.js
+++ b/src/kendo.dropdownlist.js
@@ -166,6 +166,9 @@ var __meta__ = {
             that.element.off(ns);
             that._inputWrapper.off(ns);
 
+            that._arrow.off();
+            that._arrow = null;
+
             Select.fn.destroy.call(that);
         },
 


### PR DESCRIPTION
Fix memory leak with saved reference to dropdown arrow with mousedown event.
