### PR TITLE
Update kendo.button.js

### DIFF
--- a/src/kendo.button.js
+++ b/src/kendo.button.js
@@ -52,6 +52,14 @@ var __meta__ = {
 
             kendo.notify(that);
         },
+        
+        destroy: function() {
+			var that = this;
+			
+			that.wrapper.off(NS);
+			
+			Widget.fn.destroy.call(that);
+		},
 
         events: [
             CLICK


### PR DESCRIPTION
Memory leak in the button - its event handlers are never turned `.off()`.
