### PR TITLE
Changed Kendo.mobile.ui.ListView.filterable.operator default from 'start...

### DIFF
--- a/src/kendo.mobile.listview.js
+++ b/src/kendo.mobile.listview.js
@@ -843,7 +843,7 @@ var __meta__ = {
                 value = this.searchInput.val(),
                 expr = value.length ? {
                     field: options.field,
-                    operator: options.operator || "startsWith",
+                    operator: options.operator || "startswith",
                     ignoreCase: options.ignoreCase,
                     value: value
                 } : null;


### PR DESCRIPTION
...sWith' to 'startswith'

The original spelling causes an exception during model binding with server-side filtering in ASP.NET MVC. The new spelling works as intended. Both spellings work for client-side filtering.
