### PR TITLE
Add support of row grid filtering for complex objects (with nested fields)

### DIFF
--- a/src/kendo.core.js
+++ b/src/kendo.core.js
@@ -2497,7 +2497,28 @@ function pad(number, digits, end) {
             }
 
             if (safe) {
-                expression = wrapExpression(expression.split("."), paramName);
+                // Find all quoted nested fields expressions
+                var dottedFields = expression.match(/'(.*?(\.).*?)'/ig);
+                if (dottedFields != null) {
+                    var shield = "_#_#_DOT_#_#_";
+                    var t;
+                    // Shield dots in nested fields expressions
+                    for (t = 0; t < dottedFields.length; t++) {
+                        var shieldedField = dottedFields[t].replace('.', shield);
+                        expression = expression.replace(dottedFields[t], shieldedField);
+                    }
+
+                    // Split shielded soure string
+                    var parts = expression.split('.');
+                    for (t = 0; t < parts.length; t++) {
+                        // Remove shield sequence from each part
+                        parts[t] = parts[t].replace(shield, '.');
+                     }
+
+                     expression = wrapExpression(parts, paramName);
+                 } else {
+                    expression = wrapExpression(expression.split("."), paramName);
+                 }
             } else {
                 expression = paramName + expression;
             }


### PR DESCRIPTION
Explanation: for objects with columns for nested field (e.g. 'name.firstName') grid widget crashes when row filtering mode is selected. I have prepared [JSFiddle](http://jsfiddle.net/nwgetmat/1/) with the bug demo.
