### PR TITLE
PanelBar Hidden Element Keyboard Nav Fix

### DIFF
--- a/src/kendo.panelbar.js
+++ b/src/kendo.panelbar.js
@@ -599,7 +599,7 @@ var __meta__ = {
                 next = item.parent(VISIBLEGROUP).parent(ITEM).next();
             }
 
-            if (!next[0] || !next.is(":visible")) {
+            if (!next[0]) {
                 next = this._first();
             }
 


### PR DESCRIPTION
Addresses an issue where hiding disabled elements will prevent the
keyboard navigation from working correctly

For Issue #253
