### PR TITLE
Fix for Uncaught TypeError: Cannot read property 'value' of null

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -307,7 +307,9 @@
                                         val = ngModel.$modelValue;
                                     }
                                     setTimeout(function(){
-                                        widget.value(val);
+                                        if (widget) {
+                                            widget.value(val);    
+                                        }
                                     }, 0);
                                 };
 


### PR DESCRIPTION
Fix for an error that is thrown when using ngInclude w/ kendo dropdownlist and ngModel binding to an object.  This is the PR for https://github.com/telerik/kendo-ui-core/issues/269
