### PR TITLE
Includes error information when triggering the dataSource requestEnd eve...

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -3001,7 +3001,7 @@ var __meta__ = {
 
         error: function(xhr, status, errorThrown) {
             this._dequeueRequest();
-            this.trigger(REQUESTEND, { });
+            this.trigger(REQUESTEND, { xhr: xhr, status: status, errorThrown: errorThrown });
             this.trigger(ERROR, { xhr: xhr, status: status, errorThrown: errorThrown });
         },
 


### PR DESCRIPTION
...nt. This is important for consumers to be able to identify that there was and error on the request and that e.response won't be there.
