### PR TITLE
'kendoRendered' event is received only by the last rendered widget's parents

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -499,7 +499,7 @@ var __meta__ = {
         digest(scope);
     }
 
-    module.factory('directiveFactory', [ '$compile', function(compile) {
+    module.factory('directiveFactory', [ '$compile', '$rootScope', function(compile, $rootScope) {
         var KENDO_COUNT = 0;
         var RENDERED = false;
 
@@ -571,7 +571,7 @@ var __meta__ = {
                         if (KENDO_COUNT === 0) {
                             if (!RENDERED) {
                                 RENDERED = true;
-                                scope.$emit("kendoRendered");
+                                $rootScope.$broadcast("kendoRendered");
                                 $("form").each(function(){
                                     var form = $(this).controller("form");
                                     if (form) {


### PR DESCRIPTION
`$emit` dispatches the event "upwards", so if the last rendered widget is deep in some tree structure, any listeners that are not parent of that widget, won't get `kendoRendered` event at all.
Broadcasting from $rootscope solves this.