### PR TITLE
Update kendo.angular.js

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -500,7 +500,9 @@ var __meta__ = {
 
                 var _wrapper = $(widget.wrapper)[0];
                 var _element = $(widget.element)[0];
-                var compile = element.injector().get("$compile");
+                if (element.injector()) {
+                   var compile = element.injector().get("$compile");
+                }
                 widget.destroy();
 
                 if (destroyRegister) {
@@ -514,7 +516,9 @@ var __meta__ = {
                     $(element).replaceWith(originalElement);
                 }
 
-                compile(originalElement)(scope);
+                if (compile) {
+                   compile(originalElement)(scope);
+                }
             }
         }, true); // watch for object equality. Use native or simple values.
         digest(scope);


### PR DESCRIPTION
This is fixing a latent issue we're seeing with the Kendo Beind process of errors on the element.inject().get of an error: "Cannot read property 'get' of 'undefined'.