### PR TITLE
Update kendo.angular.js

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -500,7 +500,10 @@ var __meta__ = {
 
                 var _wrapper = $(widget.wrapper)[0];
                 var _element = $(widget.element)[0];
-                var compile = element.injector().get("$compile");
+                var compile = null;
+                if (element.injector()) {
+                     compile = element.injector().get("$compile");
+                }
                 widget.destroy();
 
                 if (destroyRegister) {
@@ -514,7 +517,9 @@ var __meta__ = {
                     $(element).replaceWith(originalElement);
                 }
 
-                compile(originalElement)(scope);
+                if (compile) {
+                   compile(originalElement)(scope);
+                }
             }
         }, true); // watch for object equality. Use native or simple values.
         digest(scope);


### PR DESCRIPTION
Made the change with Compile property scoped to null.  This fixes an issue for us where element.inject() is undefined, therefore causing the rebind process to completely break across the board.