### PR TITLE
Window.maximize should not return null if already maximized

### DIFF
--- a/src/kendo.window.js
+++ b/src/kendo.window.js
@@ -76,7 +76,7 @@ var __meta__ = {
                 options = that.options;
 
             if (options.isMaximized || options.isMinimized) {
-                return;
+                return that;
             }
 
             that.restoreOptions = {


### PR DESCRIPTION
Always return window object to support chaining, even if window is already maximized or minimized. Fixes telerik/kendo-ui-core#541