### PR TITLE
ObservableObject to respect uid passed as parameter.

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -419,7 +419,7 @@ var __meta__ = {
                 that[field] = member;
             }
 
-            that.uid = kendo.guid();
+            that.uid = (value && value.uid) || kendo.guid();
         },
 
         shouldSerialize: function(field) {


### PR DESCRIPTION
For us the lack of control over the uid of the ObservableObject is a problem. Having widgets that which ds is updated frequently the easiest way to work with the data items is by uid. But updating the DS will change the uid which can sometimes cause problems. 

I know we can set additional properties to the data items but for example in the threeView when using templates for the items you do not have control over the <li> tag that is generated which contains the uid and can be used for some customization. To be more specific we do a custom drag and drop and sometimes we need to update the DS of the treeView after the drag is started but before it ends. At that moment the item we are draging holds the old uid and is not refreshed with the new one. When dropping this cause an error because we can only relate the old item to the newly generated one by their uids. 