### PR TITLE
Update kendo.multiselect.js

### DIFF
--- a/src/kendo.multiselect.js
+++ b/src/kendo.multiselect.js
@@ -382,8 +382,9 @@ var __meta__ = {
 
             that.currentTag(null);
             that._change();
-            if(that.popup.visible())
+            if(that.popup.visible()) {
                 that._close();
+            }
         },
 
         _tagListClick: function(e) {

--- a/src/kendo.multiselect.js
+++ b/src/kendo.multiselect.js
@@ -382,7 +382,8 @@ var __meta__ = {
 
             that.currentTag(null);
             that._change();
-            that._close();
+            if(that.popup.visible())
+                that._close();
         },
 
         _tagListClick: function(e) {


### PR DESCRIPTION
Added check to see if popup is visible before attempting to close. This caused an issue if autoClose is set to false, the multi select has a value applied during initialisation and the tag is removed by the user without opening the popup.