### PR TITLE
Add reduce, reduceRight to ObservableArray

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -295,7 +295,7 @@ var __meta__ = {
             }
 
             return result;
-        };
+        },
 
         reduceRight: function(callback, initialValue) {
             var idx = this.length - 1,
@@ -312,7 +312,7 @@ var __meta__ = {
             }
 
             return result;
-        };
+        },
 
         filter: function(callback) {
             var idx = 0,

--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -279,6 +279,55 @@ var __meta__ = {
             return result;
         },
 
+        reduce: function(callback, initialValue) {
+            var idx = 0,
+                result,
+                length = this.length;
+
+            if (arguments.length == 2) {
+                result = arguments[1];
+            } else {
+                while (idx < length && !(idx in this)) {
+                    idx++; 
+                }
+                if (idx < length) {
+                    result = this[idx++];
+                }
+            }
+
+            for (; idx < length; idx++) {
+                if (idx in this) {
+                    result = callback(result, this[idx], idx, this);
+                }
+            }
+
+            return result;
+        };
+
+        reduceRight: function(callback, initialValue) {
+            var idx = this.length,
+                result;
+
+            if (arguments.length == 2) {
+                result = arguments[1];
+            } else {
+                while (idx >= 0 && !(idx in this)) {
+                    idx--; 
+                }
+                if (idx > 0) {
+                    result = this[idx--];
+                }
+            }
+
+            for (; idx >= 0; idx--) {
+                if (idx in this) {
+                    result = callback(result, this[idx], idx, this);
+                }
+            }
+
+            return result;
+        };
+
         filter: function(callback) {
             var idx = 0,
                 result = [],

--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -286,43 +286,29 @@ var __meta__ = {
 
             if (arguments.length == 2) {
                 result = arguments[1];
-            } else {
-                while (idx < length && !(idx in this)) {
-                    idx++; 
-                }
-                if (idx < length) {
-                    result = this[idx++];
-                }
+            } else if (idx < length) {
+                result = this[idx++];
             }
 
             for (; idx < length; idx++) {
-                if (idx in this) {
-                    result = callback(result, this[idx], idx, this);
-                }
+                result = callback(result, this[idx], idx, this);
             }
 
             return result;
         };
 
         reduceRight: function(callback, initialValue) {
-            var idx = this.length,
+            var idx = this.length - 1,
                 result;
 
             if (arguments.length == 2) {
                 result = arguments[1];
-            } else {
-                while (idx >= 0 && !(idx in this)) {
-                    idx--; 
-                }
-                if (idx > 0) {
-                    result = this[idx--];
-                }
+            } else if (idx > 0) {
+                result = this[idx--];
             }
 
             for (; idx >= 0; idx--) {
-                if (idx in this) {
-                    result = callback(result, this[idx], idx, this);
-                }
+                result = callback(result, this[idx], idx, this);
             }
 
             return result;

--- a/tests/data/observable-array.js
+++ b/tests/data/observable-array.js
@@ -1,0 +1,113 @@
+(function(){
+
+module("ObservableArray reduce");
+
+test("reduce visits each element from the low index to high index", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        expected = "123abc",
+        actual;
+
+    actual = array.reduce(function (previous, current) {
+        return previous + current;
+    });
+
+    equal(actual, expected);
+});
+
+test("reduce starts with initial value when provided", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        initialValue = "z",
+        expected = "z123abc",
+        actual;
+
+    actual = array.reduce(function (previous, current) {
+        return previous + current;
+    }, initialValue);
+
+    equal(actual, expected);
+});
+
+test("reduce on an empty array returns undefined", function () {
+    var source = [],
+        array = new kendo.data.ObservableArray(source),
+        expected = undefined,
+        actual;
+
+    actual = array.reduce(function (previous, current) {
+        return previous + current;
+    });
+
+    equal(actual, expected);
+});
+
+test("reduce passes index of collection to callback for each element", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        expected = "112345",
+        actual;
+
+    actual = array.reduce(function (previous, current, index) {
+        return previous.toString() + index.toString();
+    });
+
+    equal(actual, expected);
+});
+
+module("ObservableArray reduceRight");
+
+test("reduceRight visits each element from the high index to low index", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        expected = "cba321",
+        actual;
+
+    actual = array.reduceRight(function (previous, current) {
+        return previous + current;
+    });
+
+    equal(actual, expected);
+});
+
+test("reduceRight starts with initial value when provided", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        initialValue = "z",
+        expected = "zcba321",
+        actual;
+
+    actual = array.reduceRight(function (previous, current) {
+        return previous + current;
+    }, initialValue);
+
+    equal(actual, expected);
+});
+
+test("reduceRight on an empty array returns undefined", function () {
+    var source = [],
+        array = new kendo.data.ObservableArray(source),
+        expected = undefined,
+        actual;
+
+    actual = array.reduceRight(function (previous, current) {
+        return previous + current;
+    });
+
+    equal(actual, expected);
+});
+
+test("reduceRight passes index of collection to callback for each element", function () {
+    var source = ["1", "2", "3", "a", "b", "c"],
+        array = new kendo.data.ObservableArray(source),
+        expected = "c43210",
+        actual;
+
+    actual = array.reduceRight(function (previous, current, index) {
+        return previous.toString() + index.toString();
+    });
+
+    equal(actual, expected);
+});
+
+}());


### PR DESCRIPTION
Implementation based on current implementation of `ObservableArray.map` and the polyfill implementation on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce).

The implementation does not handle support for sparse arrays due to inherent issues with `ObservableArray`

Here is a link that includes some very basic qunit tests: https://jsfiddle.net/gconnolly/7ycz1dzm/