### PR TITLE
Correctly check if widget has enable function

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -263,7 +263,7 @@ var __meta__ = {
     }
 
     function bindToKNgDisabled(widget, scope, element, kNgDisabled) {
-        if ((kendo.ui.PanelBar && widget instanceof kendo.ui.PanelBar) || (kendo.ui.Menu && widget instanceof kendo.ui.Menu)) {
+        if (typeof widget.enable != "function") {
             $log.warn("k-ng-disabled specified on a widget that does not have the enable() method: " + (widget.options.name));
             return;
         }


### PR DESCRIPTION
Currently k-ng-disabled is strictly not supported for PanelBar and Menu but on the other side there is no check if the widget has an enable function. The log message is misleading since PanelBar has an enable function.

I don't see any reason why k-ng-disabled should not work for all widgets having an enabled function and therefore the check should be on the existence of the function (as it is already done for k-ng-readonly)