### PR TITLE
Add documentation which widgets support k-ng-disabled and k-ng-readonly.

### DIFF
--- a/docs/AngularJS/introduction.md
+++ b/docs/AngularJS/introduction.md
@@ -419,6 +419,8 @@ To watch multiple options for change, just use `k-options` and pass the same var
 
 With the 2015 Q1 release support for `k-ng-disabled` and `k-ng-readonly` directives has been introduced. Using them you can change the disabled/readonly state of the widget based on a scope variable.
 
+`k-ng-disabled` is supported by all widgets containing an `enabled` method, `k-ng-readonly` by all widgets containing an `readonly` method.
+
 #### Change disabled state
 
 ```html

--- a/docs/AngularJS/introduction.md
+++ b/docs/AngularJS/introduction.md
@@ -419,7 +419,7 @@ To watch multiple options for change, just use `k-options` and pass the same var
 
 With the 2015 Q1 release support for `k-ng-disabled` and `k-ng-readonly` directives has been introduced. Using them you can change the disabled/readonly state of the widget based on a scope variable.
 
-`k-ng-disabled` is supported by all widgets containing an `enabled` method, `k-ng-readonly` by all widgets containing an `readonly` method.
+`k-ng-disabled` is supported by all widgets containing an `enabled` method, except the PanelBar and Menu widget. `k-ng-readonly` by all widgets containing an `readonly` method.
 
 #### Change disabled state
 


### PR DESCRIPTION
Add documentation which widgets support k-ng-disabled and k-ng-readonly. Takes PR #925 into account, otherwise PanelBar and Menu are not supported by k-ng-disabled even though they support an enabled function.