### PR TITLE
Correctly check if widget has enable function

### DIFF
--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -263,6 +263,10 @@ var __meta__ = {
     }
 
     function bindToKNgDisabled(widget, scope, element, kNgDisabled) {
+        if (typeof widget.enable != "function") {
+            $log.warn("k-ng-disabled specified on a widget that does not have the enable() method: " + (widget.options.name));
+            return;
+        }
         if ((kendo.ui.PanelBar && widget instanceof kendo.ui.PanelBar) || (kendo.ui.Menu && widget instanceof kendo.ui.Menu)) {
             $log.warn((widget.options.name) + " does not support k-ng-disabled.");
             return;

--- a/src/kendo.angular.js
+++ b/src/kendo.angular.js
@@ -264,7 +264,7 @@ var __meta__ = {
 
     function bindToKNgDisabled(widget, scope, element, kNgDisabled) {
         if ((kendo.ui.PanelBar && widget instanceof kendo.ui.PanelBar) || (kendo.ui.Menu && widget instanceof kendo.ui.Menu)) {
-            $log.warn("k-ng-disabled specified on a widget that does not have the enable() method: " + (widget.options.name));
+            $log.warn((widget.options.name) + " does not support k-ng-disabled.");
             return;
         }
         scope.$watch(kNgDisabled, function(newValue, oldValue) {


### PR DESCRIPTION
Based on #925. Show correct log message if k-ng-disabled is used on PanelBar or Menu and checks if widget on which k-ng-disables is used contains an enable function.