### PR TITLE
automatically create output directory if it's not existing

### DIFF
--- a/docs/_plugins/redirect_generator.rb
+++ b/docs/_plugins/redirect_generator.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 module Jekyll
     class RedirectGenerator < Generator
         def initialize(config)
@@ -11,6 +12,7 @@ module Jekyll
             web_config = Page.new(site, site.source, '', 'web.config')
             web_config.content = File.read(File.join(site.source, 'web.config'))
             web_config.render(Hash.new, site.site_payload)
+            FileUtils.mkdir_p(site.dest)
             File.write(File.join(site.dest, 'web.config'), web_config.output)
 
             site.static_files << web_config


### PR DESCRIPTION
that way, jekyll serve (as described in README.md) runs on a clean clone of the repository, because "_site" is in .gitignore.