### PR TITLE
Source binding should destroy widgets

### DIFF
--- a/src/kendo.binder.js
+++ b/src/kendo.binder.js
@@ -1735,6 +1735,8 @@ var __meta__ = {
                 element.kendoBindingTarget = null;
             }
         }
+
+        kendo.destroy(element);
     }
 
     function unbindElementTree(element) {


### PR DESCRIPTION
Source binding needs to destroy widgets that it creates.

Motivation:
Right now, the source binding creates widgets, but it never destroys them.  If you have drop down list widgets in a source binding template, they will create elements as children of the body tag.  The source binding never destroys the widget, so those elements never go away.  Every time the source binding refreshes the number of elements in the DOM goes up. This dramatically effects performance and memory usage.

Fix:
Use standard kendo.destroy method at the same place in the code data bindings are destroyed.

This has been reported in an issue: https://github.com/telerik/kendo-ui-core/issues/862