### PR TITLE
Source binding should destroy widgets

### DIFF
--- a/src/kendo.binder.js
+++ b/src/kendo.binder.js
@@ -28,6 +28,7 @@ var __meta__ = {
         CHECKED = "checked",
         CSS = "css",
         deleteExpando = true,
+        FUNCTION = "function",
         CHANGE = "change";
 
     (function() {
@@ -579,7 +580,7 @@ var __meta__ = {
 
             for (idx = 0; idx < items.length; idx++) {
                 var child = element.children[index];
-                unbindElementTree(child);
+                unbindElementTree(child, true);
                 element.removeChild(child);
             }
         },
@@ -601,7 +602,7 @@ var __meta__ = {
             }
 
             if (this.bindings.template) {
-                unbindElementChildren(element);
+                unbindElementChildren(element, true);
 
                 $(element).html(this.bindings.template.render(source));
 
@@ -900,7 +901,7 @@ var __meta__ = {
                     items = e.removedItems || widget.items();
 
                 for (idx = 0, length = items.length; idx < length; idx++) {
-                    unbindElementTree(items[idx]);
+                    unbindElementTree(items[idx], false);
                 }
             },
 
@@ -1634,7 +1635,7 @@ var __meta__ = {
         parents = parents || [source];
 
         if (role || bind) {
-            unbindElement(element);
+            unbindElement(element, false);
         }
 
         if (role) {
@@ -1721,7 +1722,7 @@ var __meta__ = {
         }
     }
 
-    function unbindElement(element) {
+    function unbindElement(element, destroyWidget) {
         var bindingTarget = element.kendoBindingTarget;
 
         if (bindingTarget) {
@@ -1735,20 +1736,29 @@ var __meta__ = {
                 element.kendoBindingTarget = null;
             }
         }
+        
+        if(destroyWidget) {
+            var data = $(element).data();
+            for (var key in data) {
+                if (key.indexOf("kendo") === 0 && typeof data[key].destroy === FUNCTION) {
+                    data[key].destroy();
+                }
+            }
+        }
     }
 
-    function unbindElementTree(element) {
-        unbindElement(element);
+    function unbindElementTree(element, destroyWidgets) {
+        unbindElement(element, destroyWidgets);
 
-        unbindElementChildren(element);
+        unbindElementChildren(element, destroyWidgets);
     }
 
-    function unbindElementChildren(element) {
+    function unbindElementChildren(element, destroyWidgets) {
         var children = element.children;
 
         if (children) {
             for (var idx = 0, length = children.length; idx < length; idx++) {
-                unbindElementTree(children[idx]);
+                unbindElementTree(children[idx], destroyWidgets);
             }
         }
     }
@@ -1759,7 +1769,7 @@ var __meta__ = {
         dom = $(dom);
 
         for (idx = 0, length = dom.length; idx < length; idx++ ) {
-            unbindElementTree(dom[idx]);
+            unbindElementTree(dom[idx], false);
         }
     }
 


### PR DESCRIPTION
Source binding needs to destroy widgets that it creates.

Motivation:
Right now, the source binding creates widgets, but it never destroys them. If you have drop down list widgets in a source binding template, they will create elements as children of the body tag. The source binding never destroys the widget, so those elements never go away. Every time the source binding refreshes the number of elements in the DOM goes up. This dramatically effects performance and memory usage.

Fix:
Destroy all widget references inside an element of the source binding.  This is safe, because those elements are immediately removed from the DOM.  There is no way the widgets will be re-used.

Limitations:
This fixes the source binding when used independently of a widget.  I suspect that a similar problem can occur with the widget variant of the source binding.  However, I don't see any simple fix for that, since there is no clear way to tell whether it is safe to destroy the widgets or not.  

This is related to issue #862