### PR TITLE
Fix tooltip popup still shows when destroyed

### DIFF
--- a/src/kendo.tooltip.js
+++ b/src/kendo.tooltip.js
@@ -425,6 +425,8 @@ var __meta__ = {
                 popup.destroy();
             }
 
+            clearTimeout(this.timeout);
+
             this.element.off(NS);
 
             DOCUMENT.off("keydown" + NS, this._documentKeyDownHandler);

--- a/tests/tooltip/tooltip.js
+++ b/tests/tooltip/tooltip.js
@@ -477,4 +477,17 @@
 
         equal(tooltip.content.html(), "");
     });
+
+    asyncTest("dont show popup when tooltip destroyed after mouseenter", function() {
+        var tooltip = new Tooltip(container, { showAfter: 5 });
+
+        triggerEvent(container, "mouseenter");
+        tooltip.destroy();
+
+        setTimeout(function() {
+          start();
+          ok(!(tooltip.popup && tooltip.popup.visible()));
+        }, 10);
+    });
+
 })();


### PR DESCRIPTION
Closes #1054 

How to reproduce:

1. Make a tooltip with a delay.
2. Move your mouse on it.
3. Somehow call tooltip.destroy() before the popup shows up.
4. Note that the popup still shows up.

My context is that, the button that shows up the tooltip, when clicked
on will also navigate to another state(like another page, but only part
of page content is changed) in my angular SPA. The popup will still show
up after the click. The popup delay is 1000ms.