### PR TITLE
Bumped acceptable JQuery version to 2.1.x

### DIFF
--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -21,10 +21,10 @@ with Kendo UI service packs. We can do this for major releases.
 
 The following list provides jQuery compatibility information about the major Kendo UI releases and their corresponding service packs:
 
-* Kendo UI 2015.2.624 (Q2 2015) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
-* Kendo UI 2015.1.318 (Q1 2015) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
-* Kendo UI 2014.3.1119 (Q3 2014) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
-* Kendo UI 2014.2.716 (Q2 2014) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
+* Kendo UI 2015.2.624 (Q2 2015) - jQuery 1.9.1 (also works with 1.10.x and 2.1.x)
+* Kendo UI 2015.1.318 (Q1 2015) - jQuery 1.9.1 (also works with 1.10.x and 2.1.x)
+* Kendo UI 2014.3.1119 (Q3 2014) - jQuery 1.9.1 (also works with 1.10.x and 2.1.x)
+* Kendo UI 2014.2.716 (Q2 2014) - jQuery 1.9.1 (also works with 1.10.x and 2.1.x)
 * Kendo UI 2014.1.318 (Q1 2014) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
 * Kendo UI 2013.3.1119 (Q3 2013) - jQuery 1.9.1 (also works with 1.10.x and 2.0.x)
 * Kendo UI 2013.2.716 (Q2 2013) - jQuery 1.9.1


### PR DESCRIPTION
Since in bower.json it already states that I can use Kendo UI with jquery 2.1.1. This change was introduced here

https://github.com/kendo-labs/bower-kendo-ui/blob/599736581baf4243b09b1eb04be25ae5b5bfbb47/bower.json

by @gyoshev in July 2014, so I presume this is true here as well. Can you please update this so that I can get consistent version numbers in the documentation here http://docs.telerik.com/kendo-ui/install/prerequisites