### PR TITLE
Kendo should not enforce global install of grunt. Use Grunt-cli

### DIFF
--- a/docs/install/custom.md
+++ b/docs/install/custom.md
@@ -52,7 +52,7 @@ shipped source, run the following shell commands:
 
 ```sh
     cd src
-    npm install -g grunt
+    npm install -g grunt-cli
     npm install
     grunt custom:autocomplete,dropdownlist
 ```


### PR DESCRIPTION
Grunt-cli is the preferred way of installing Grunt globally. `grunt-cli` is a wrapper which picks the correct version of Grunt.

This way, Kendo will always pick the correct version of grunt.

This requires two changes. 

1. here on documentation page, which will require you to install `grunt-cli` instead of `grunt` globally.
2. ~~in package.json, which must also load preferred grunt version~~


And I can see that grunt is already loaded in package.json
