### PR TITLE
Fix DateTimePicker when using ISO date format

### DIFF
--- a/src/kendo.datetimepicker.js
+++ b/src/kendo.datetimepicker.js
@@ -744,9 +744,9 @@ var __meta__ = {
         options.format = extractFormat(options.format || patterns.g);
         options.timeFormat = timeFormat = extractFormat(options.timeFormat || patterns.t);
         kendo.DateView.normalize(options);
-
+        
         if (parseFormats) {
-            options.parseFormats.push("yyyy-MM-ddTHH:mm:ss");
+           options.parseFormats.unshift("yyyy-MM-ddTHH:mm:ss");
         }
 
         if ($.inArray(timeFormat, options.parseFormats) === -1) {

--- a/tests/datetimepicker/api.js
+++ b/tests/datetimepicker/api.js
@@ -711,6 +711,14 @@ test("value method can set 1/1/1970", function() {
     deepEqual(datepicker.dateView._value, date);
 });
 
+test("value method parses hours when ISO dateformat", 1, function() {
+    var datetimepicker = new DateTimePicker(input, {
+        value: "2000-10-10T13:30:23"
+    });
+
+    equal(datetimepicker.element.val(), "10/10/2000 1:30 PM");
+});
+
 test("setOptions method sets correct timeView min/max values", function() {
     var date = new Date(2013, 10, 10, 1, 30);
     var min = new Date(2013, 10, 9, 23, 30);

--- a/tests/datetimepicker/api.js
+++ b/tests/datetimepicker/api.js
@@ -711,7 +711,7 @@ test("value method can set 1/1/1970", function() {
     deepEqual(datepicker.dateView._value, date);
 });
 
-test("value method parses hours when ISO dateformat", 1, function() {
+test("value method parses hours when ISO date format", 1, function() {
     var datetimepicker = new DateTimePicker(input, {
         value: "2000-10-10T13:30:23"
     });


### PR DESCRIPTION
The DateTimePicker does not parse the hour correctly because of the order of parseFormats. The most generic format ("yyyy-MM-dd") comes first into the array so the hour is never considered.