### PR TITLE
Run gulp through node for more predictable behavior.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,7 +229,7 @@ module.exports = function(grunt) {
                 stderr: false
             },
             gulpStyles: {
-                command: 'node_modules/gulp/bin/gulp.js styles'
+                command: 'node node_modules/gulp/bin/gulp.js styles'
             }
         },
 


### PR DESCRIPTION
```npm run build``` was erroring out on my Windows machine with: 

```
Warning: Command failed: C:\WINDOWS\system32\cmd.exe /s /c "node_modules/gulp/bin/gulp.js styles"
'node_modules' is not recognized as an internal or external command,
operable program or batch file.
```

Rather than relying on the Shebang being respected, it's easier just to run it with node.