### PR TITLE
Sample code not working for 'depth' option

### DIFF
--- a/docs/api/javascript/ui/datepicker.md
+++ b/docs/api/javascript/ui/datepicker.md
@@ -178,7 +178,8 @@ shows the decades from the century
     <input id="datepicker"/>
     <script>
     $("#datepicker").kendoDatePicker({
-        depth: "year"
+        depth: "year",
+        start: "year"
     });
     </script>
 


### PR DESCRIPTION
In the documentation is stated that:
"Note the option will not be applied if "start" option is "lower" than "depth". Always set both and "start" and "depth" options.

But the given example is without the 'start' option, so it is not working correctly. I put both "start" and "depth" set as "year" and now the example is working as expected.