### PR TITLE
Added default for contentUrls property in options

### DIFF
--- a/src/kendo.panelbar.js
+++ b/src/kendo.panelbar.js
@@ -272,6 +272,7 @@ var __meta__ = { // jshint ignore:line
                     duration: 200
                 }
             },
+            contentUrls: [],
             expandMode: "multiple"
         },
 


### PR DESCRIPTION
This is so we can correctly generate `@bindable` properties for the Aurelia UI toolkit project. We could manually add these bindables but it's a lot more flexible and resilient if they are generated from the options object on each widgets proto.

https://github.com/aurelia-ui-toolkits/aurelia-kendoui-bridge/issues/285