### PR TITLE
Updated pt and pt-PT cultures to the official Portuguese standard

### DIFF
--- a/src/cultures/kendo.culture.pt-PT.js
+++ b/src/cultures/kendo.culture.pt-PT.js
@@ -4,13 +4,13 @@
         numberFormat: {
             pattern: ["-n"],
             decimals: 2,
-            ",": " ",
+            ",": "",
             ".": ",",
             groupSize: [3],
             percent: {
                 pattern: ["-n%","n%"],
                 decimals: 2,
-                ",": " ",
+                ",": "",
                 ".": ",",
                 groupSize: [3],
                 symbol: "%"
@@ -20,7 +20,7 @@
                 abbr: "EUR",
                 pattern: ["-n $","n $"],
                 decimals: 2,
-                ",": " ",
+                ",": ".",
                 ".": ",",
                 groupSize: [3],
                 symbol: "€"
@@ -40,11 +40,11 @@
                 AM: [""],
                 PM: [""],
                 patterns: {
-                    d: "dd/MM/yyyy",
+                    d: "yyyy-MM-dd",
                     D: "d' de 'MMMM' de 'yyyy",
                     F: "d' de 'MMMM' de 'yyyy HH:mm:ss",
-                    g: "dd/MM/yyyy HH:mm",
-                    G: "dd/MM/yyyy HH:mm:ss",
+                    g: "yyyy-MM-dd HH:mm",
+                    G: "yyyy-MM-dd HH:mm:ss",
                     m: "d' de 'MMMM",
                     M: "d' de 'MMMM",
                     s: "yyyy'-'MM'-'dd'T'HH':'mm':'ss",
@@ -54,7 +54,7 @@
                     y: "MMMM' de 'yyyy",
                     Y: "MMMM' de 'yyyy"
                 },
-                "/": "/",
+                "/": "-",
                 ":": ":",
                 firstDay: 0
             }

--- a/src/cultures/kendo.culture.pt.js
+++ b/src/cultures/kendo.culture.pt.js
@@ -4,26 +4,26 @@
         numberFormat: {
             pattern: ["-n"],
             decimals: 2,
-            ",": ".",
+            ",": "",
             ".": ",",
             groupSize: [3],
             percent: {
                 pattern: ["-n%","n%"],
                 decimals: 2,
-                ",": ".",
+                ",": "",
                 ".": ",",
                 groupSize: [3],
                 symbol: "%"
             },
             currency: {
-                name: "",
-                abbr: "",
-                pattern: ["-$ n","$ n"],
+                name: "Euro",
+                abbr: "EUR",
+                pattern: ["-n $","n $"],
                 decimals: 2,
                 ",": ".",
                 ".": ",",
                 groupSize: [3],
-                symbol: "R$"
+                symbol: "€"
             }
         },
         calendars: {
@@ -40,11 +40,11 @@
                 AM: [""],
                 PM: [""],
                 patterns: {
-                    d: "dd/MM/yyyy",
-                    D: "dddd, d' de 'MMMM' de 'yyyy",
-                    F: "dddd, d' de 'MMMM' de 'yyyy HH:mm:ss",
-                    g: "dd/MM/yyyy HH:mm",
-                    G: "dd/MM/yyyy HH:mm:ss",
+                    d: "yyyy-MM-dd",
+                    D: "d' de 'MMMM' de 'yyyy",
+                    F: "d' de 'MMMM' de 'yyyy HH:mm:ss",
+                    g: "yyyy-MM-dd HH:mm",
+                    G: "yyyy-MM-dd HH:mm:ss",
                     m: "d' de 'MMMM",
                     M: "d' de 'MMMM",
                     s: "yyyy'-'MM'-'dd'T'HH':'mm':'ss",
@@ -54,7 +54,7 @@
                     y: "MMMM' de 'yyyy",
                     Y: "MMMM' de 'yyyy"
                 },
-                "/": "/",
+                "/": "-",
                 ":": ":",
                 firstDay: 0
             }


### PR DESCRIPTION
The official PT standard for dates is "NP EN 28601" and not what Windows
says it is.
Windows default date and time formats for PT are wrong.

So dates are represented as "yyyy-mm-dd" and not as "dd/mm/yyyy".