### PR TITLE
Add missing message localization(de-DE) to scheduler

### DIFF
--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -430,6 +430,7 @@ $.extend(true, kendo.ui.Scheduler.prototype.options.messages,{
     "timelineMonth": "Zeitstrahl Monat"
   },
   "deleteWindowTitle": "Termin löschen",
+  "defaultRowText": "Alle Termine",
   "showFullDay": "Ganzen Tag anzeigen",
   "showWorkDay": "Geschäftszeiten anzeigen",
   "ariaSlotLabel": "Ausgewählt von {0:t} bis {1:t}",


### PR DESCRIPTION
Not much to say about this. Just noticed it when working on my scheduler in timeline view.
I dont know, if this string is missing in other languages also.

My CLA is already submitted and open for review.