### PR TITLE
Fix: set slider tickPlacement values case sensitive

### DIFF
--- a/docs/api/javascript/ui/slider.md
+++ b/docs/api/javascript/ui/slider.md
@@ -57,21 +57,21 @@ The small step value determines the amount of Slider value change when the end u
 Denotes the location of the tick marks in the **Slider**. The available options are:
 
 
-#### *"topLeft"*
+##### *"topLeft"*
 
 Tick marks are located on the top of the horizontal widget or on the left of
   the vertical widget.
 
-#### *"bottomRight"*
+##### *"bottomRight"*
 
 Tick marks are located on the bottom of the horizontal widget or on the
   right side of the vertical widget.
 
-#### *"both"*
+##### *"both"*
 
 Tick marks are located on both sides of the widget.
 
-#### *"none"*
+##### *"none"*
 
 Tick marks are not visible.
 


### PR DESCRIPTION
Fix: Tickplacement property values are case sensitive. These values are
in uppercase as "text-transform: uppercase;" is set in sytle.css for
"#markdown-toc + #page-article h4".
Changed these properties style from h4 to h5.