### PR TITLE
kendo.ui.FilterCell was missing isnull/isempty messages.

### DIFF
--- a/src/messages/kendo.messages.pt-PT.js
+++ b/src/messages/kendo.messages.pt-PT.js
@@ -145,7 +145,11 @@ $.extend(true, kendo.ui.FilterCell.prototype.options.operators,{
     "startswith": "Começa com",
     "contains": "Contém",
     "doesnotcontain": "Não contém",
-    "endswith": "Termina com"
+    "endswith": "Termina com",
+    "isnull": "É nulo",
+    "isnotnull": "É não nulo",
+    "isempty": "É vazio",
+    "isnotempty": "É não vazio"
   },
   "number": {
     "eq": "É igual a",
@@ -153,7 +157,9 @@ $.extend(true, kendo.ui.FilterCell.prototype.options.operators,{
     "gte": "É maior ou igual a",
     "gt": "É maior que",
     "lte": "É menor ou igual a",
-    "lt": "É menor que"
+    "lt": "É menor que",
+    "isnull": "É nulo",
+    "isnotnull": "É não nulo"
   },
   "date": {
     "eq": "É igual a",
@@ -161,11 +167,15 @@ $.extend(true, kendo.ui.FilterCell.prototype.options.operators,{
     "gte": "É posterior ou igual a",
     "gt": "É posterior a",
     "lte": "É anterior ou igual a",
-    "lt": "É anterior a"
+    "lt": "É anterior a",
+    "isnull": "É nulo",
+    "isnotnull": "É não nulo"
   },
   "enums": {
     "eq": "É igual a",
-    "neq": "Não é igual a"
+    "neq": "Não é igual a",
+    "isnull": "É nulo",
+    "isnotnull": "É não nulo"
   }
 });
 }


### PR DESCRIPTION
kendo.ui.FilterCell was missing isnull/isempty, isnotnull/isnotempty text messages.

This was making the FilterCell menu to not translate these options.