### PR TITLE
allow Widget template to be an id or template instance

### DIFF
--- a/src/kendo.core.js
+++ b/src/kendo.core.js
@@ -2851,7 +2851,11 @@ function pad(number, digits, end) {
             if (value !== undefined) {
 
                 if (templateRegExp.test(option)) {
-                    value = kendo.template($("#" + value).html());
+                    if(typeof value === "string") {
+                        value = kendo.template($("#" + value).html());
+                    } else {
+                        value = element.getAttribute(option);
+                    }
                 }
 
                 result[option] = value;

--- a/tests/core/widget.js
+++ b/tests/core/widget.js
@@ -150,4 +150,65 @@ test("plugin callback is called for existing and new widgets", 2, function() {
     kendo.widgets = currentWidgets;
     kendo._widgetRegisteredCallbacks = [];
 });
+
+asyncTest("Widget can be extended with static Kendo template", function() {
+
+    var currentWidgets = kendo.widgets;
+    kendo.widgets = [];
+
+    expect(1);
+
+    var template = kendo.template('<some-element></some-element>');
+    var Widget1 = kendo.ui.Widget.extend({
+
+        options: {
+            name: "HtmlTemplateWidget",
+            prefix: ""
+        },
+        init: function(element, options) {
+
+            options = options || {};
+
+            element.getAttribute = function(key) {
+                switch (key) {
+                    case 'data-template':
+                    case 'template':
+                        return template;
+                        break;
+                    default:
+                        return Element.prototype.getAttribute.call(element, key);
+                        break;
+                }
+                
+            }
+
+            options.template = template;
+            kendo.ui.Widget.fn.init.call(this, element, options);
+
+        }
+    });
+
+    kendo.ui.plugin(Widget1);
+
+    kendo.onWidgetRegistered(function(entry) {
+
+        if(entry.name === 'kendoHtmlTemplateWidget') {
+            var el = $('<some-test-element />');
+            el.kendoHtmlTemplateWidget();
+
+            deepEqual(template, el.data("kendoHtmlTemplateWidget").options.template);
+
+            // reset the state
+            el.data("kendoHtmlTemplateWidget").destroy();
+            kendo.widgets = currentWidgets;
+            kendo._widgetRegisteredCallbacks = [];
+
+            start();
+
+        }
+
+    });
+
+});
+
 }());


### PR DESCRIPTION
When using Webcomponents for an element that extended `DataBoundWidget` and that was loaded via HTML5 Imports, it's not possible to access the template's source element from the application's root DOM.

The extended constructor (with access to the Webcomponent's document) could directly create that template and pass the result into the Widget's options.

This change allows to skip the forced template creation if not a string (the Element's id attribute) is provided.
