### PR TITLE
Push event not supported by HierarchicalDataSource

### DIFF
--- a/docs/api/javascript/data/hierarchicaldatasource.md
+++ b/docs/api/javascript/data/hierarchicaldatasource.md
@@ -228,6 +228,8 @@ The **remove** and **getByUid** methods are overridden and work with the hierarc
 
 See the [DataSource events](/api/framework/datasource#events) for all inherited events.
 
+> Disclaimer: The [push](/api/framework/datasource#events-push) event is not currently supported by the `HierarchicalDataSource`.
+
 ### change
 
 Fires when data is changed. In addition to the [standard change event](/api/framework/datasource#change),


### PR DESCRIPTION
Per the Support ID:1023962. The push event is not currently supported by the HierarchicalDataSource. I think users should know about that. I personally spent some time figuring this out, because I thought it would work since the API documentation only states that you can inherit all the events from the DataSource class.