### PR TITLE
updated webpack intergration config

### DIFF
--- a/docs/third-party/webpack.md
+++ b/docs/third-party/webpack.md
@@ -66,7 +66,7 @@ $("#dropdownlist").kendoDropDownList({
 var path = require('path')
 module.exports = {
     resolve: {
-        extensions: [ '', '.js', 'min.js' ],
+        extensions: [ '', '.js', '.min.js' ],
         root: [
             path.resolve('.'),
             path.resolve('../kendo/dist/js/') // the path to the minified scripts

--- a/docs/third-party/webpack.md
+++ b/docs/third-party/webpack.md
@@ -69,7 +69,7 @@ module.exports = {
         extensions: [ '', '.js', '.min.js' ],
         root: [
             path.resolve('.'),
-            path.resolve('../kendo/dist/js/') // the path to the minified scripts
+            path.resolve('../kendo/dist/js/') // the path to the minified scripts, if you want to use some widgets like treeview which define 'util/main' as deps, you have to use src js files
         ]
     },
     entry: './main',


### PR DESCRIPTION
add ['.min.js'] and comments, for some widgets using 'util/main', developers have to use src js for webpack