### PR TITLE
Add docs about Editor thumbnails known issue in MVC Core

### DIFF
--- a/docs/aspnet-mvc/aspnetmvc-apps/mvc-6/known-issues.md
+++ b/docs/aspnet-mvc/aspnetmvc-apps/mvc-6/known-issues.md
@@ -69,6 +69,10 @@ Server-side rendering is not supported. The Toolbar template, Column Header temp
 | `ChartScatterLineMissingValues` | `ChartSeriesMissingValues`|
 | `ChartScatterLineStyle`   | `ChartSeriesStyle`      |
 
+### Editor
+
+The Thumbnails view of ImageBrowser is not supported because the **System.Drawing** namespace is [not part of ASP.NET Core](https://blogs.msdn.microsoft.com/dotnet/2016/02/10/porting-to-net-core/). However, a third-party library can be used for the server-side processing of images.
+
 ### MultiSelect
 
 The `TagMode` enum is now by `MultiSelectTagMode`.


### PR DESCRIPTION
We do not provide the Thumnails view of ImageBrowser as the **System.Drawing** namespace is missing form ASP.NET Core.