### PR TITLE
Internal builds not available via CDN

### DIFF
--- a/docs/intro/installation/cdn-service.md
+++ b/docs/intro/installation/cdn-service.md
@@ -23,6 +23,9 @@ For example, the {{ site.cdnVersion }} version can be loaded from:
 `http://kendo.cdn.telerik.com/{{ site.cdnVersion }}/js/kendo.all.min.js`
 `http://kendo.cdn.telerik.com/{{ site.cdnVersion }}/styles/kendo.common.min.css`
 
+Please note only official releases and services packs are uploaded to CDN.
+Internal builds are not published to CDN.
+
 Use the following URL to load the minified Kendo UI Core script (available since Q1 2014 SP1):
 `http://kendo.cdn.telerik.com/{{ site.cdnVersion }}/js/kendo.ui.core.min.js`
 


### PR DESCRIPTION
This wasted some time of our team. Would be helpful to make it clear.