### PR TITLE
Enable tabbed snippets in documentation

### DIFF
--- a/docs/_assets/javascripts/app.js
+++ b/docs/_assets/javascripts/app.js
@@ -150,7 +150,7 @@ function preventParentSelection(e) {
 }
 
 $(function(){
-    $("pre[lang]").each(function() {
+    $("pre[data-lang^=tab-]").each(function() {
         if (this.parentNode.className.indexOf("k-content") >= 0) {
             return;
         }
@@ -158,7 +158,8 @@ $(function(){
         var langs = $(this).nextUntil(":not(pre)", "pre").add(this);
 
         var tabs = $.map(langs, function(item) {
-            return $("<li>").text($(item).attr("lang"));
+            var title = $(item).attr("data-lang").replace("tab-", "");
+            return $("<li>").text(title);
         });
 
         if (tabs.length < 2) {

--- a/docs/_assets/stylesheets/styles.css
+++ b/docs/_assets/stylesheets/styles.css
@@ -723,28 +723,39 @@ footer p {
 }
 
 .k-tabstrip {
+    border: 1px solid #ccc;
+}
+
+.k-tabstrip .k-link {
+    padding: 0;
+}
+
+.k-tabstrip .k-content,
+.k-tabstrip .k-loading {
     border: 0;
+}
+
+.k-tabstrip .k-tabstrip-items {
+    padding: 0;
+    border-bottom: 1px solid;
 }
 
 .k-tabstrip .k-item {
-    border-width: 0 1px 0;
-    border-color: #acacac;
+    border-width: 0 1px 0 0;
+    border-style: solid;
+    font-weight: bold;
+    font-size: 14px;
+    padding: .72em 1.5em;
+    cursor: pointer;
+    transition-property: background-color, color;
+    transition-duration: 0.2s;
+    transition-timing-function: ease;
 }
 
-.k-tabstrip .k-content {
-    border-color: #acacac;
-    background: #F1F5F9;
-}
 .k-tabstrip .k-content pre {
     border: 0;
-}
-
-.k-tabstrip .k-tabstrip-items .k-state-active {
-    border-bottom-width: 0;
-    margin-bottom: -1px;
-    padding-bottom: -1px;
-    z-index: 1;
-    background: #F1F5F9;
+    padding: 0;
+    margin: 1em 0;
 }
 
 @media (max-width: 1200px) {

--- a/docs/_assets/stylesheets/theme.css
+++ b/docs/_assets/stylesheets/theme.css
@@ -344,7 +344,6 @@
     text-decoration: none;
     background-color: #e8ebef;
     color: #000;
-    
 }
 
 .action-buttons .active-button,
@@ -384,35 +383,31 @@
     box-sizing: border-box;
 }
 
-.k-tabstrip {
-    border: 1px solid #ebecee;
-}
-
-.k-tabstrip .k-item,
-.k-tabstrip .k-link,
-.k-tabstrip .k-content,
-.k-tabstrip .k-content pre,
-.k-tabstrip .k-loading {
-    border: 0;
+.k-tabstrip .k-tabstrip-items,
+.k-tabstrip .k-item {
+    border-color: #e8ebef;
 }
 
 .k-tabstrip .k-tabstrip-items {
-    background: #f5f7f8;
+    background: #fefefe;
 }
 
-.k-tabstrip .k-tabstrip-items .k-state-active .k-link {
-    font-weight: bold;
+.k-tabstrip .k-item {
+    color: #333;
+}
+
+.k-tabstrip .k-item:hover {
+    background-color: #e8ebef;
     color: #000;
 }
 
-.k-tabstrip .k-content {
-    background: #fff;
+.k-tabstrip .k-item.k-state-active,
+.k-tabstrip .k-item.k-state-active:hover {
+    background-color: #e8ebef;
+    color: #333;
 }
 
-.k-tabstrip .prettyprint {
-    padding: 0;
-}
-
+.k-tabstrip,
 .prettyprint {
     border-color: #e8ebef;
     background-color: #f9f9f9;


### PR DESCRIPTION
Revive tabbed snippet code and update tabstrip styles. Used in [migration help topics](cbdd7f2ba7f9) and when showing syntax flavors (ASPX / Razor). Syntax is <code>```tab-**TabName**</code>.