### PR TITLE
"Add autoscroll support when custom hint is used

### DIFF
--- a/src/kendo.draganddrop.js
+++ b/src/kendo.draganddrop.js
@@ -799,15 +799,16 @@ var __meta__ = { // jshint ignore:line
             e.preventDefault();
 
             var cursorElement = this._elementUnderCursor(e);
+
+            if (this.options.autoScroll && this._cursorElement !== cursorElement) {
+                this._scrollableParent = findScrollableParent(cursorElement);
+                this._cursorElement = cursorElement;
+            }
+
             this._lastEvent = e;
             this._processMovement(e, cursorElement);
 
             if (this.options.autoScroll) {
-                if (this._cursorElement !== cursorElement) {
-                    this._scrollableParent = findScrollableParent(cursorElement);
-                    this._cursorElement = cursorElement;
-                }
-
                 // chrome seems to trigger mousemove when mouse is moved outside of the window (over the Chrome), too.
                 if (this._scrollableParent[0]) {
                     var velocity = autoScrollVelocity(e.x.location, e.y.location, scrollableViewPort(this._scrollableParent));


### PR DESCRIPTION
"Add autoscroll support when custom hint is used by getting the scrollable parent before triggering the "drag" event. Fixes #1638