### PR TITLE
AutoComplete: the span with loading icon is duplicated ...

### DIFF
--- a/src/kendo.autocomplete.js
+++ b/src/kendo.autocomplete.js
@@ -672,7 +672,9 @@ var __meta__ = { // jshint ignore:line
         },
 
         _loader: function() {
-            this._loading = $('<span class="k-icon k-loading" style="display:none"></span>').insertAfter(this.element);
+            var loadSpan = this.element.next("span.k-loading");
+            this._loading = loadSpan.length ?
+                loadSpan : $('<span class="k-icon k-loading" style="display:none"></span>').insertAfter(this.element);
         },
 
         _toggleHover: function(e) {


### PR DESCRIPTION
… when a new autocomplete widget is created from the leftovers of a destroyed one. This leads to "_showBusy" function displays all ".k-loading" spans, but "_hideBusy" function hides only one span, and loading icon stays visible forever after has been displayed once.

I have carefully read the documentation about [widget destroying](http://docs.telerik.com/kendo-ui/intro/widget-basics/destroy) and I know that widgets creation from leftovers is not recommended, but I consider this PR is possible for the following reasons:
1. In "_wrapper" method already exist check for leftovers: whether the input field is wrapped in a span? If so, the new span is not created.
2. It is not always possible to manipulate (add/remove) elements in the DOM: in particular, I use Kendo UI framework from [Apache Wicket](http://wicket.apache.org) framework with [Kendo UI integration in Wicket](https://github.com/sebfz1/wicket-jquery-ui) library; removing some elements from page markup can lead to wrong behavior of Wicket components.

Of course, I can do some workaround for this issue in integration library mentioned above, but because autocomplete widget already has some checks for leftovers, another one check IMHO will be useful.
