### PR TITLE
Fix missing 'Filter' translation on kendo.ui.ColumnMenu

### DIFF
--- a/src/messages/kendo.messages.pl-PL.js
+++ b/src/messages/kendo.messages.pl-PL.js
@@ -76,6 +76,7 @@ $.extend(true, kendo.ui.FilterMenu.prototype.options.operators,{
 if (kendo.ui.ColumnMenu) {
 kendo.ui.ColumnMenu.prototype.options.messages =
 $.extend(true, kendo.ui.ColumnMenu.prototype.options.messages,{
+  "filter": "Filtr",
   "columns": "Kolumny",
   "sortAscending": "Sortuj Rosnąco",
   "sortDescending": "Sortuj malejąco",


### PR DESCRIPTION
In Polish the kendo.ui.ColumnMenu has no translation for 'filter'.