### PR TITLE
Corrected duplicated xAxis narrowRange setting

### DIFF
--- a/docs/api/javascript/dataviz/ui/chart.md
+++ b/docs/api/javascript/dataviz/ui/chart.md
@@ -25540,7 +25540,7 @@ Setting it to `false` will force the automatic axis range to snap to 0.
           xAxis: {
             narrowRange: true
           },
-          xAxis: {
+          yAxis: {
             narrowRange: true
           }
         });


### PR DESCRIPTION
The example should show setting the xAxis and the yAxis, like the one below it.