### PR TITLE
fix possible memory leak in mobile list view

### DIFF
--- a/src/kendo.mobile.listview.js
+++ b/src/kendo.mobile.listview.js
@@ -116,9 +116,17 @@ var __meta__ = { // jshint ignore:line
             listView.bind(STYLED, cacheHeaders);
             listView.bind(DATABOUND, cacheHeaders);
 
-            scroller.bind("scroll", function(e) {
+            this._scrollHandler = function(e) {
                 headerFixer._fixHeader(e);
-            });
+            };
+            scroller.bind("scroll", this._scrollHandler);
+        },
+
+        destroy: function() {
+            var that = this;
+            if (that.scroller) {
+                that.scroller.unbind("scroll", that._scrollHandler);
+            }
         },
 
         _fixHeader: function(e) {
@@ -1023,6 +1031,10 @@ var __meta__ = { // jshint ignore:line
                 this._itemBinder.destroy();
             }
 
+            if(this._headerFixer) {
+                this._headerFixer.destroy();
+            }
+
             this.element.unwrap();
             delete this.element;
             delete this.wrapper;
@@ -1090,6 +1102,7 @@ var __meta__ = { // jshint ignore:line
         replace: function(dataItems) {
             this.options.type = "flat";
             this._angularItems("cleanup");
+            kendo.destroy(this.element.children());
             this.element.empty();
             this._userEvents.cancel();
             this._style();


### PR DESCRIPTION
When a HeaderFixer is initialized, it creates a binding to the listview's scroller. But when the listview is destroyed, this binding is not removed. It can become an issue if the scroller is not on the listview itself, but some parent element. The binding will hold a reference to headerFixer until the scroller is destroyed.

I ran into this issue with a listview containing a list of listviews. All of the child listviews used the parent's scroller. When the datasource of the parent listview changed, the child listviews were recreated, but remnants of the old children remained in memory.

In order to fix this I had to make changes in a few places. In HeaderFixer, a reference to the scrollHandler is now saved so we can remove in the destroy function. When the listview is destroyed, we need to call destroy on the headerFixer as well.

Also, before removing the elements in a listview, we need to destroy them.