### PR TITLE
Fix popup close without effects should hide wrapper #5326

### DIFF
--- a/src/kendo.popup.js
+++ b/src/kendo.popup.js
@@ -382,6 +382,10 @@ var __meta__ = { // jshint ignore:line
                 that.element.kendoStop(true);
                 wrap.css({ overflow: HIDDEN }); // stop callback will remove hidden overflow
                 that.element.kendoAnimate(animation);
+
+                if (skipEffects) {
+                    that._animationClose();
+                }
             }
         },
 

--- a/tests/popup/popup.js
+++ b/tests/popup/popup.js
@@ -175,6 +175,15 @@
         }, 400);
     });
 
+    test("popup close(true) hides wrapper", function() {
+        popup = div.kendoPopup().data("kendoPopup");
+
+        popup.open();
+        popup.close(true);
+
+        equal(popup.wrapper.css("display"), "none");
+    });
+
     test("popup is made absolute", function() {
         div.kendoPopup();
         popup = div.data('kendoPopup');


### PR DESCRIPTION
The bulk of changes in `tests/popup/popup.js` is due to the line endings and me using Windows.