### PR TITLE
Grid docs update

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,24 +31,33 @@ navigation:
     "controls/data-management/grid/how-to/AngularJS":
         title: "AngularJS"
         position: 1
+    "controls/data-management/grid/how-to/binding":
+        title: "Binding"
+        position: 2
     "controls/data-management/grid/how-to/Editing":
         title: "Editing"
-        position: 2
+        position: 3
+    "controls/data-management/grid/how-to/filtering":
+        title: "Filtering"
+        position: 4
     "controls/data-management/grid/how-to/Layout":
         title: "Appearance"
-        position: 3
+        position: 5
     "controls/data-management/grid/how-to/Selection":
         title: "Selection"
-        position: 4
+        position: 6
     "controls/data-management/grid/how-to/Templates":
         title: "Templates"
-        position: 5
+        position: 7
+    "controls/data-management/grid/how-to/hidden":
+        title: "Hidden Containers"
+        position: 8
     "controls/data-management/grid/how-to/excel":
         title: "Excel Export"
-        position: 6
+        position: 9
     "controls/data-management/grid/how-to/pdf-export":
         title: "PDF Export"
-        position: 7
+        position: 10
     "controls/editors":
         title: "Editors"
         position: 2

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,6 +58,9 @@ navigation:
     "controls/data-management/grid/how-to/Templates":
         title: "Templates"
         position: 10
+    "controls/data-management/grid/how-to/state":
+        title: "State Management"
+        position: 11
     "controls/editors":
         title: "Editors"
         position: 2

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,32 +31,32 @@ navigation:
     "controls/data-management/grid/how-to/AngularJS":
         title: "AngularJS"
         position: 1
-    "controls/data-management/grid/how-to/binding":
-        title: "Binding"
-        position: 2
-    "controls/data-management/grid/how-to/Editing":
-        title: "Editing"
-        position: 3
-    "controls/data-management/grid/how-to/filtering":
-        title: "Filtering"
-        position: 4
     "controls/data-management/grid/how-to/Layout":
         title: "Appearance"
+        position: 2
+    "controls/data-management/grid/how-to/binding":
+        title: "Binding"
+        position: 3
+    "controls/data-management/grid/how-to/Editing":
+        title: "Editing"
+        position: 4
+    "controls/data-management/grid/how-to/excel":
+        title: "Export to Excel"
         position: 5
-    "controls/data-management/grid/how-to/Selection":
-        title: "Selection"
+    "controls/data-management/grid/how-to/pdf-export":
+        title: "Export in PDF"
         position: 6
-    "controls/data-management/grid/how-to/Templates":
-        title: "Templates"
+    "controls/data-management/grid/how-to/filtering":
+        title: "Filtering"
         position: 7
     "controls/data-management/grid/how-to/hidden":
         title: "Hidden Containers"
         position: 8
-    "controls/data-management/grid/how-to/excel":
-        title: "Excel Export"
+    "controls/data-management/grid/how-to/Selection":
+        title: "Selection"
         position: 9
-    "controls/data-management/grid/how-to/pdf-export":
-        title: "PDF Export"
+    "controls/data-management/grid/how-to/Templates":
+        title: "Templates"
         position: 10
     "controls/editors":
         title: "Editors"

--- a/docs/controls/data-management/grid/adaptive.md
+++ b/docs/controls/data-management/grid/adaptive.md
@@ -169,17 +169,13 @@ The recommended approach is to call [`kendo.destroy()`](/api/javascript/kendo#me
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
-* [Blog Post for Building An Adaptive Grid and Scheduler for Kendo UI](http://blogs.telerik.com/kendoui/posts/13-10-10/building-an-adaptive-grid-and-scheduler-for-kendo-ui)
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/adaptive.md
+++ b/docs/controls/data-management/grid/adaptive.md
@@ -8,7 +8,9 @@ position: 6
 
 # Adaptive Rendering
 
-As of the Kendo UI Q3 2013 release, the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience. For instance, when filtering or editing data on a mobile device, Kendo UI slides in a new screen for the user, which is a departure from the more desktop-like inline and popup behaviors. To see those features in action, check the [adaptive rendering demos](http://demos.telerik.com/kendo-ui/m/index#grid/adaptive).
+As of the [Kendo UI Q3 2013 release](http://www.telerik.com/blogs/new-in-kendo-ui-q3-2013), the Grid supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
+
+For instance, when you filter or edit data on a mobile device, Kendo UI slides in a new screen for the user, which is a departure from the rather desktop-like inline and popup behaviors. To see these features in action, refer to the [adaptive rendering demos](http://demos.telerik.com/kendo-ui/m/index#grid/adaptive).
 
 ## Getting Started
 
@@ -36,11 +38,13 @@ To enable the adaptive rendering feature, set the [`mobile`](/api/javascript/ui/
     });
     </script>
 
+### Prerequisites
+
 The Kendo UI adaptive mode requires scripts, which are normally part of the Kendo UI Mobile (Hybrid) library (`kendo.mobile.min.js`). However, these scripts are also included in `kendo.web.min.js` and `kendo.all.min.js`. If you are using [individual widget scripts]({% slug include_only_what_you_need_kendoui_installation %}#individual-widget-scripts) or a [custom combined script]({% slug include_only_what_you_need_kendoui_installation %}#employ-download-builder), make sure the relevant scripts are included.
 
 ## Pane Configuration
 
-The mobile pane in which the adaptive Grid is placed does not automatically expand its height. To add an adaptive Grid to a kendo UI mobile application, set the `stretch` configuration of the respective view to `true`, or explicitly define the height of the widget.
+The mobile pane in which the adaptive Grid is placed does not automatically expand its height. To add an adaptive Grid to a Kendo UI mobile application, set the `stretch` configuration of the respective view to `true`, or explicitly define the height of the widget.
 
 ### Use the stretch Option
 
@@ -122,7 +126,7 @@ This section applies to the following cases:
 * When multiple adaptive Grids are used on the same page.
 * When the Grid is not the only content on the page.
 
-Each adaptive Grid is rendered inside a separate mobile pane. Since the position of the panes is absolute, the panes overlap. To avoid this issue, wrap each Grid inside a `<div>` container that is relatively positioned and has a set height. The absolute position is required for the transition between main and edit views to work correctly.
+Each adaptive Grid is rendered inside a separate mobile pane. Because the position of the panes is absolute, the panes overlap. To avoid this behavior, wrap each Grid inside a `<div>` container that is relatively positioned and has a set height. The absolute position is required for the transition between main and edit views to work correctly.
 
 The example below demonstrates how to add multiple adaptive Grids to the same page.
 

--- a/docs/controls/data-management/grid/appearance.md
+++ b/docs/controls/data-management/grid/appearance.md
@@ -64,7 +64,7 @@ When you apply virtual scrolling, the HTML output is different.
 >
 > To achieve a maximum level of accessibility through assistive technologies, disable the scrolling feature of the Grid.
 
-### Remove Vertical Scrollbar
+### Remove the Vertical Scrollbar
 
 When you enable the scrolling functionality of the Grid, its vertical scrollbar is always visible even if it is not needed. This simplifies the implementation and improves the performance of the widget.
 
@@ -88,7 +88,7 @@ The `#GridID` allows the application of styles only to a particular Grid instanc
 
 ### Restore Scroll Positions
 
-In some scenarios, the scroll position of the Grid might be reset when the widget is rebound. If you want to avoid this behavior, save the scroll position in the [`dataBinding`](/api/javascript/ui/grid#events-dataBinding) event and restore it in the [`dataBound`](/api/javascript/ui/grid#events-dataBound) event. The scrollable container is `div.k-grid-content` and you can retrieve it as a child element of the widget [`wrapper`]({% slug widgetwrapperandelement_references_gettingstarted %}).
+In some scenarios, the scroll position of the Grid might be reset when the widget is rebound. To avoid this behavior, save the scroll position in the [`dataBinding`](/api/javascript/ui/grid#events-dataBinding) event and restore it in the [`dataBound`](/api/javascript/ui/grid#events-dataBound) event. The scrollable container is `div.k-grid-content` and it is possible to retrieve it as a child element of the widget [`wrapper`]({% slug widgetwrapperandelement_references_gettingstarted %}).
 
 If virtual scrolling is enabled, the scrollable data container is `div.k-virtual-scrollable-wrap` and it is scrolled only horizontally.
 
@@ -213,49 +213,40 @@ If the total number of items is large and the scrolling is fast, the table of th
 
 When virtual scrolling is not supported or recommended, revert to standard paging or non-virtual scrolling without paging, depending on the number of data items.
 
-## Width
-
-By default, the Grid has no width and behaves like a block-level element. This means that it expands to the width of its parent element.
-
-If you enable the scrolling functionality of the Grid and the sum of all column widths is greater than the width of the Grid, a horizontal scrollbar will appear.
-
-If you disable the scrolling functionality of the Grid and the columns are not able to fit, they will overflow the Grid `<div>`. This results in the widget's right border passing through the data cells. The reason for this is that, basically, the Grid is a `<table>` element inside a `<div>` one. Tables can expand horizontally beyond 100% to enclose their content, while `<div>` elements lack this behavior.
-
-Possible solutions for table overflowing are:
-
-* Enable the scrolling functionality, which, by default, is disabled when using the Kendo UI Grid MVC wrapper.
-* Set a large-enough width or a min-width style for the Grid wrapper, the `<div class="k-widget k-grid">` element.
-* [Float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) the Grid wrapper and [clear](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) the float right after the widget. Floated elements expand and shrink automatically to enclose their content when needed. Use this approach only if the previous two are unacceptable.
-
-When you use hierarchy, the detail template content cannot be wider than the master table, unless the detail template is scrollable.
-
 ## Height
 
-By default, the Grid has no height and expands to fit all table rows. For historical reasons, the Grid MVC wrapper [applies a default height of 200px to its data area](/aspnet-mvc/helpers/grid/configuration#scrolling) when scrolling is enabled.
+By default, the Grid has no height and expands to fit all table rows. To provide for a backwards compatibility, the scrollable MVC wrapper of the Grid [applies a default height of 200px to its scrollable data area](/aspnet-mvc/helpers/grid/configuration#scrolling). To control the height of the widget, specify a static pixel value.
 
-Set the height of the Grid in one of the following ways:
+###### Example
+
+    $("#grid").kendoGrid({
+        height: 100,
+        // other configuration
+    });
+
+To set the height of the Grid, use any of the following approaches:
 
 * Apply an inline height style to the `<div>` from which the Grid is initialized.
-* Use the `height` property of the widget, which will apply an inline style to the Grid wrapper, i.e. the same as the above option.
-* Use external CSS, e.g. use the ID or CSS class (`.k-grid`) of the Grid to apply a height style.
+* Use the `height` property of the widget, which will apply an inline style to the Grid wrapper&mdash;the same as the previous option.
+* Use external CSS. For example, use the ID or the `.k-grid` CSS class to apply a height style.
 
-It makes sense to set a height to the Grid only if its scrolling is enabled.
+It is advisable to set a height to the Grid only if its scrolling is enabled.
 
-When the Grid has a set height, it calculates the appropriate height of its scrollable data area, so that the sum of the header rows, filter row, data, footer, and pager is equal to the expected Grid height. That is why you have to call the [`resize` method of the Grid]({% slug responsivewebdesign_integration_kendoui %}) afterwards if the Grid height is changed through JavaScript after you create the widget. In this way the Grid recalculates the height of its data area.
+When the height of the Grid is set, it calculates the appropriate height of its scrollable data area, so that the sum of the header rows, filter row, data, footer, and pager is equal to the expected height of the widget. That is why if the height of the Grid is changed through JavaScript after you create the widget,  you need to call the [`resize` method of the Grid]({% slug responsivewebdesign_integration_kendoui %}) afterwards. In this way the Grid recalculates the height of its data area.
 
 **Figure 1. Grid with a fixed height and its scrolling functionality enabled**
 
 ![Grid With Fixed Height And Scrolling](/controls/data-management/grid/grid3_1.png)
 
-In some special scenarios it is possible to set a height style to the scrollable data area of the Grid, either through JavaScript or external CSS, which is a `div.k-grid-content` element. In this case, do not set height to the Grid.
+In some special scenarios it is possible to set a height style to the scrollable data area of the Grid either by using JavaScript or external CSS, which is a `div.k-grid-content` element. In this case it is not recommended to set height to the Grid.
 
 ### Let the Height Vary within Limits
-
-It is possible to make the Grid expand and shrink vertically according to the number of its rows and yet within certain limits. To achieve this, do not set a height of the Grid and apply a minimum and/or maximum height style to the scrollable data area. Make sure you [remove the default data area height]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) if you use the MVC wrapper.
 
 > **Important**
 >
 > This approach is not applicable when virtual scrolling is enabled.
+
+It is possible to make the Grid expand and shrink vertically according to the number of its rows and yet within certain limits. To achieve this, apply a minimum and/or maximum height style to the scrollable data area and do not set any height of the Grid. If you use the MVC wrapper of the Grid, make sure you [remove the default data area height]({% slug configuration_gridhelper_aspnetmvc %}#scrolling).
 
 ###### Example
 
@@ -265,21 +256,23 @@ It is possible to make the Grid expand and shrink vertically according to the nu
         max-height: 400px;
     }
 
-You can use the `.k-grid` class instead of the `GridID` to target all widget instances.
+It is also possible to use the `.k-grid` class instead of the `GridID` to target all widget instances.
 
-### Set a 100% Height and Auto-Resize
+### Set 100% Height and Auto-Resize
 
 > **Important**
 >
 > This section is applicable to scrollable Grids only.
 
-To make the Grid 100% high and resize together with its parent, first apply a 100% height style to the Grid [(i.e. to the widget's `<div class="k-grid">` wrapper)]({% slug widgetwrapperandelement_references_gettingstarted %}). According to web standards, elements with a percentage height require that their parent has an explicit height. This requirement applies recursively either until an element with a pixel height, or the `html` element is reached. Elements that are 100% high cannot have margins, paddings, borders, or sibling elements, so remove the default border of the Grid as well.
+To make the Grid 100% high and resize together with its parent, you need to apply a 100% height style to the widget&mdash;[that is, to the `<div class="k-grid">` wrapper of the widget]({% slug widgetwrapperandelement_references_gettingstarted %}). According to web standards, elements with a percentage height require that their parent has an explicit height. This requirement applies recursively until either an element with a pixel height, or the `html` element is reached. Elements that are 100% high cannot have margins, paddings, borders, or sibling elements. That is why you have to remove the default border of the Grid as well.
 
-Secondly, ensure that the inner Grid layout adapts to changes in the height of the Grid wrapper `<div>`. If those changes are triggered by browser window resizing, subscribe to the window `resize` event of the browser and execute the [`resize`]({% slug responsivewebdesign_integration_kendoui %}) method of the Grid. The `resize` method will take care of measuring the height of the Grid `<div>` and adjusting the height of the scrollable data area. You do not need to call the `resize` method if the Grid is placed inside a Kendo UI Splitter or Kendo UI Window, because these widgets will execute it automatically. Also, you do not need the method if you use locked (frozen) columns.
+Then, you need to make sure that the inner layout of the Grid adapts to changes in the height of the `<div>` wrapper. If these changes are triggered by the resizing of the browser window, subscribe to the window `resize` event of the browser and execute the [`resize`]({% slug responsivewebdesign_integration_kendoui %}) method of the Grid. The `resize` method measures the height of the Grid `<div>` and adjusts the height of the scrollable data area.
 
-If the available vertical space for the Grid depends on a custom layout resizing controlled by the user, use a suitable event or method related to the layout changes to execute the `resize` method of the Grid. In this case, call the `resize` method even if you use locked (frozen) columns.
+If the Grid is placed inside a Kendo UI Splitter or Kendo UI Window, you do not need to call the `resize` method because these widgets will execute it automatically. Also, it is not necessary to apply the method if you use locked (frozen) columns.
 
-The `resize` method will work for Kendo UI versions delivered after the Kendo UI Q3 2013 release. For older versions, use the following Javascript code instead of `resize`, which practically does the same.
+If the vertical space that is available for the Grid depends on a custom resizing of the layout, which is controlled by the user, use a suitable event or method related to the layout changes to execute the `resize` method of the Grid. In this case, call the `resize` method even if you use locked columns.
+
+The `resize` method works for the Kendo UI versions delivered after the Kendo UI Q3 2013 release. For older versions, instead of `resize`, use the following approach which practically functions in the same way.
 
 ###### Example
 
@@ -296,56 +289,81 @@ The `resize` method will work for Kendo UI versions delivered after the Kendo UI
         gridElement.children(".k-grid-content").height(newHeight - otherElementsHeight);
     });
 
-The [article on how to resize the Grid when the window is resized]({% slug howto_resize_whenthe_windowis_resized_grid %}) contains a runnable example of the discussed scenario.
+For a runnable example of the previously discussed scenario, refer to the article on [how to resize the Grid when the window is resized]({% slug howto_resize_whenthe_windowis_resized_grid %}).
 
-### Loading Indicator
+### Configure the Loading Indicator
 
-The Grid internally uses the [`kendo.ui.progress`](/api/javascript/ui/ui#methods-progress) method to display a loading overlay during remote `read` requests. If the scrolling Grid functionality is disabled, the overlay is displayed over the whole Grid. If scrolling is enabled, the overlay is displayed over the scrollable data area.
+Internally, the Grid uses the [`kendo.ui.progress`](/api/javascript/ui/ui#methods-progress) method to display a loading overlay during remote `read` requests.
 
-If the scrolling Grid functionality is enabled and the Grid has no height, the data area will initially have a zero height, which will make the loading overlay invisible during the first remote request. This issue can be resolved in two ways: either set a Grid height, or apply a `min-height` style to the `div.k-grid-content` element. For more information, refer to the [the example of setting the height within certain limits](#let-the-height-vary-within-limits).
+If the scrolling functionality of the Grid is disabled, the overlay is displayed over the whole Grid.
+
+If scrolling is enabled, the overlay is displayed over the scrollable data area.
+
+If scrolling is enabled and the Grid has no set height, the data area will initially have a zero height, which will make the loading overlay invisible during the first remote request. This issue can be resolved in two ways:
+
+* Set the height of the Grid
+* Apply the `min-height` style to the `div.k-grid-content` element.
+
+For more information, refer to the [the example of setting the height within certain limits](#let-the-height-vary-within-limits).
+
+## Width
+
+By default, the Grid has no width and behaves like a block-level element. This means that similar to all block elements it expands to a 100% width, that is, to the width of its parent element.
+
+The width of the Grid can be controlled by setting the CSS width properties for the Grid itself or for some of its ancestors. If you use hierarchy and unless the detail template is scrollable, the detail template has to be narrower than the total width of all master columns.
+
+If you enable the scrolling functionality of the Grid and the sum of all column widths is greater than the width of the Grid, a horizontal scrollbar appears.
+
+If you disable the scrolling functionality of the Grid and the columns do not fit, they overflow the `<div>` element of the Grid. This results in the widget's right border passing through the data cells. The reason for this is that, basically, the Grid is a `<table>` element inside a `<div>` one. Tables can expand horizontally beyond 100% to enclose their content, while `<div>` elements lack this behavior.
+
+Possible solutions for table overflowing are:
+
+* Enable the scrolling functionality, which, by default, is disabled when using the Kendo UI Grid MVC wrapper.
+* Set a large-enough width or a min-width style for the Grid wrapper&mdash;the `<div class="k-widget k-grid">` element.
+* [Float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) the Grid wrapper and [clear](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) the float right after the widget. Floated elements expand and shrink automatically to enclose their content when needed. Use this approach only if the previous two are unacceptable.
 
 ## Columns
 
-### Widths
+### Column Widths
 
-The Grid columns behave differently, depending on whether scrolling is enabled, or not.
+The columns of the Grid behave differently, depending on whether scrolling is enabled, or not.
 
-When the scrolling functionality is enabled, which is the default case except for the Grid MVC wrapper, the `table-layout` style of the Grid tables is set to `fixed`. This means that all columns without a defined width will appear equally wide, no matter what their content is, and will expand or shrink depending on the available space. If there is not enough horizontal space, columns without a defined width may even shrink to a zero width. All set column widths will be obeyed no matter what the cell content is. If the content cannot fit, it will be either wrapped, or clipped. During column resizing, only the resized column will change its width and the other column widths will be persisted. To achieve this, the table width will change.
+By default, scrolling is enabled&mdash;except for the MVC wrapper of the Grid&mdash;and the `table-layout` style of the Grid tables is set to `fixed`. This means that all columns without a defined width will appear equally wide no matter what their content is. If there is not enough horizontal space, columns without a defined width might even shrink to a zero width. All set column widths will be obeyed regardless of the cell content. If the content cannot fit, it will either be wrapped or clipped. During the resizing of columns, only the resized column will change its width and the other columns will persist their widths. To achieve this, the width of the table will change altogether.
 
-When the scrolling functionality is disabled, the `table-layout` style is set to `auto`. This is the default behavior of HTML tables. If not explicitly set, the column widths are determined by the browser and cell content. The browser will try to obey all set column widths, but may readjust some columns depending on their content. The column widths may change on paging, sorting, and other data operations.
+When scrolling is disabled, the `table-layout` style is set to `auto`, which is the default behavior of HTML tables. This means that if not explicitly set, the column widths are determined by the browser and by the cell content. The browser will try to obey all column widths that are set, but might readjust some columns depending on their content.
 
-If needed, a fixed table layout can be applied to a non-scrollable Grid.
+If needed, apply a fixed table layout to a non-scrollable Grid.
 
 ###### Example
 
-    #GridID > table /* includes both the header and the data cells */
+    #GridID > table /* header + data table */
     {
         table-layout: fixed;
     }
 
 <!--*-->
-Column widths should be set only via the `width` property of the Grid columns. Using table cell width styles is not recommended. When creating the Grid from an HTML `table`, column widths can be set via width styles of the table `col` elements.
+Column widths are set only through the `width` property of the Grid columns. It is not recommended to use width styles for table cells. It is possible to set the width of the columns through the `col` elements when you create a Grid from an HTML `table`.
 
 > **Important**
 >
-> [Scrolling makes the Grid render separate tables for the header and data area](#scrolling). These tables must have synchronized column widths. This can be ensured only when the `table-layout` is `fixed`. As a result, it is not possible to have a scrollable Grid with automatic table layout, i.e. automatic column widths, which depend on the cell content.
+> [The Grid renders separate tables for the header and data area when scrolling is enabled](#scrolling). These tables need to have column widths that are synchronized. To ensure this, configure `table-layout` to `fixed`. As a result, it is not possible to have a scrollable Grid with automatic table layout&mdash;that is, automatic column widths, which depend on the cell content.
 
-If all columns have pixel widths and their sum exceeds the width of the Grid, a horizontal scrollbar appears if scrolling is enabled. If that sum is less than the width of the Grid, the column widths are ignored and all columns expand. This leads to undesired side effects, e.g. when resizing columns. In old Internet Explorer versions the column widths are obeyed, but misalignment occurs. That is why it is recommended to have at least one column without a specified width, so that it can adjust freely. Set explicit widths for all columns only if they are set in percent, or if their sum exceeds the Grid width and the goal is to achieve horizontal scrolling.
+When all columns have pixel widths, their sum exceeds the width of the Grid, and scrolling is enabled, a horizontal scrollbar appears. If that sum is less than the width of the Grid, the column widths are ignored and all columns expand. This leads to undesired side effects&mdash;for example, when resizing columns. In old Internet Explorer versions, the column widths are obeyed, but misalignment occurs. That is why it is recommended to have at least one column without a specified width, so that it can adjust freely. Set explicit widths for all columns only if they are set in percentage, or if their sum exceeds the width of the Grid and the goal is to achieve horizontal scrolling.
 
-Column resizing and hiding trigger the following behavior when scrolling is enabled: if all currently visible columns have explicit widths, the Grid applies a pixel width to its table elements, so that the widths of all remaining columns, i.e. except the column that is currently resized or hidden, are maintained.
+When you resize and hide columns, scrolling is enabled, and all currently visible columns have explicit widths, the Grid applies a pixel width to its table elements, so that the widths of all remaining columns are maintained (except for the column that is currently resized or hidden).
 
-If the Grid has no fixed width and resizes with the browser window, you can apply a min-width to the Grid if scrolling is disabled, or its two table elements if scrolling is enabled. This prevents undesired side effects if the browser window size is reduced too much.
+If the Grid has no fixed width, resizes with the browser window, and scrolling is disabled, it is possible to apply a minimum width to the Grid. If the Grid has no fixed width, resizes with the browser window, and scrolling is enabled, it is possible to apply a minimum width to its two table elements. This prevents undesired side effects if the size of the browser window is reduced too much.
 
 ###### Example
 
-    /* How to apply minimum width to the Grid when scrolling is disabled */
+    /* Apply minimum width to the Grid when scrolling is disabled. */
 
     #GridID
     {
         min-width: 800px;
     }
 
-    /* How to apply minimum width to the Grid tables when scrolling is enabled and nested tables (hierarchy) ARE NOT USED */
+    /* Apply a minimum width to the tables when scrolling is enabled and nested tables (hierarchy) ARE NOT USED. */
 
     #GridID .k-grid-header-wrap > table, /* header table */
     #GridID .k-grid-content table, /* data table, no virtual scrolling */
@@ -354,7 +372,7 @@ If the Grid has no fixed width and resizes with the browser window, you can appl
         min-width: 800px;
     }
 
-    /* How to apply minimum width to the Grid tables when scrolling is enabled and nested tables (hierarchy) ARE USED */
+    /* Apply a minimum width to the tables when scrolling is enabled and nested tables (hierarchy) ARE USED. */
 
     #GridID .k-grid-header-wrap > table, /* header table */
     #GridID .k-grid-content table, /* data table, no virtual scrolling */
@@ -369,21 +387,21 @@ If the Grid has no fixed width and resizes with the browser window, you can appl
     }
 
 <!--*-->
-Using the `Grid ID` (Name) in the above selectors is optional, so that the styles are applied to a particular Grid instance only.
+It is optional to use the `Grid ID` (Name) in the selectors from the previous example, which makes it possible to apply the styles to a particular Grid instance only.
 
-Setting column widths in percent is possible, but if the sum of all widths is greater than 100%, i.e. a horizontal scrollbar is desired, the Grid tables must have a (min-)width style. Otherwise, the tables will be 100% wide (as wide as the Grid) and the columns will be narrower than desired. Note that when column widths are set in percent, resizing one column may lead to other columns changing their widths as well.
+It is possible to set column widths in percentage only if the sum of all widths is greater than 100% (a horizontal scrollbar is desired) and is the Grid tables have a (min-)width style. Otherwise, the tables will be as wide as the Grid (100%) and the columns will be narrower than desired. When column widths are set in percentage, the resizing of one column might lead to the resizing of the other columns too.
 
-### Resizing
+### Column Resizing
 
-When Grid scrolling is `disabled` and a column is resized, other columns will change widths too, so that the sum of all column widths remains constant. If both the columns and the Grid `<div>` already have their minimum possible widths applied, then column resizing will stop working. In such scenarios, either apply a larger width to the Grid, or enable scrolling.
+When scrolling is disabled and a column is resized, other columns change widths too, so that the sum of all column widths remains constant. If both the columns and the Grid `<div>` already have their minimum possible widths applied, then the resizing of the columns stops working. In such scenarios, either apply a larger width to the Grid, or enable scrolling.
 
-When Grid scrolling is `enabled` and a column is resized, all other columns will maintain their widths. There are three possible outcomes of column resizing with regard to the sum of all column widths:
+When scrolling is enabled and a column is resized, all other columns maintain their widths. When column resizing is applied, there are three possible outcomes with regard to the sum of all column widths:
 
-* If it is greater than the Grid width, then a horizontal scrollbar will appear.
-* If it is equal to the Grid width, then no horizontal scrollbar will be visible.
-* If it is less than the Grid width, then empty space after the last column will appear.
+* If the sum of all column widths is greater than the width of the Grid, a horizontal scrollbar appears.
+* If the sum of all column widths is equal to the width of the Grid, no horizontal scrollbar appears.
+* If the sum of all column widths is less than the width of the Grid, an empty space after the last column appears.
 
-The last Grid column has no right border by design, so that no double border appears at the right end of the Grid if the Grid table width matches the Grid widget width, which is the most common scenario. If needed, a right border can be applied with the following CSS code.
+By design, the last column of the Grid has no right border, so that no double border appears at the right end of the Grid if the Grid table width matches the Grid widget width. If needed, it is possible to apply a right border with the CSS code from the following example.
 
 ###### Example
 
@@ -392,30 +410,31 @@ The last Grid column has no right border by design, so that no double border app
         border-right: 1px solid #ccc;
     }
 
-The `#ccc` border color value should match the cell border color from the [Kendo UI theme]({% slug themesandappearnce_kendoui_desktopwidgets %}). It can be obtained by checking the table cell styles with a DOM inspector.
+The color value of the `#ccc` border has to match the color of the cell border from the [Kendo UI theme]({% slug themesandappearnce_kendoui_desktopwidgets %}). To obtain this, check the styles of the table cell by using a DOM inspector.
 
-### Locking
+### Locked Columns
 
-Locked (frozen) columns allow some columns to be visible at all times during horizontal Grid scrolling.
+Locked (frozen) columns allow part of the columns to be visible at all times during horizontal Grid scrolling.
 
-The Grid supports frozen columns on one side of the table. In order to work properly, the feature has the following requirements to the Grid configuration:
+The Grid allows you to lock columns on one side of the table. For the feature to work properly, provide the following configuration settings:  
 
-* [Scrolling](#scrolling) must be enabled.
-* The Grid must have a defined height.
-* All columns must have explicit pixel widths set, so that the Grid can adjust the layout of the frozen and non-frozen table parts.
-* The total width of all locked columns must be equal to or less than the Grid width minus three times the scrollbar width.
+* Enable [scrolling](#scrolling).
+* Lock at least one column initially.
+* Define the height of the Grid.
+* Set explicit pixel widths to all columns to allow the Grid to adjust the layout of the frozen and non-frozen table parts.
+* Make sure that the total width of all locked columns is equal to or less than the width of the Grid minus three times the width of the scrollbar.
 
-The above ensures that at least one non-locked column is always visible and horizontal scrolling of the non-locked columns is possible.
+These settings ensure that at least one non-locked column is always visible and that it is possible to scroll the non-locked columns horizontally. Note that the horizontal scrollbar will not appear if the horizontal space intended for it is not enough.
 
-The row template and detail features are not supported in combination with column locking. If [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders) are used, it is possible to lock (freeze) a column at the topmost level only.
+The row template and detail features are not supported in combination with column locking. It is possible to lock a column at the topmost level only, if you use [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders).
 
-Frozen columns cannot be touch-scrolled, because they are wrapped in a container with an `overflow:hidden` style. This limitation can be worked around on desktop devices with the help of the mousewheel event, but it does not exist on touch devices.
+Frozen columns cannot be touch-scrolled, because they are wrapped in a container with an `overflow:hidden` style. This limitation can be worked around on desktop devices with the help of the mousewheel event, but such an alternative on touch devices does not exist.
 
 > **Important**  
 >
-> The [Grid JavaScript API](/api/javascript/ui/grid) allows columns to be locked and unlocked on the fly. However, this is possible only if at least one column is initially locked during initialization. The HTML output and script behavior of the Grid are very different when frozen columns are used. That is why the widget cannot switch between frozen and unfrozen mode after initialization.
+> The [JavaScript API of the Grid](/api/javascript/ui/grid) allows you to lock and unlock columns on the fly. However, this is possible only if at least one column is initially locked during initialization. The HTML output and script behavior of the Grid are very different when frozen columns are used. That is why the widget cannot switch between frozen and unfrozen mode after initialization.
 
-Frozen columns rely on row height synchronization between the frozen and non-frozen parts. Some browsers, such as Internet Explorer 9 and Firefox, require a `line-height` style set in pixels. Otherwise the synchronization may not work properly, probably due to some sub-pixel quirks.
+Frozen columns rely on row height synchronization between the frozen and non-frozen parts. Some browsers, such as Internet Explorer 9 and Firefox, require a `line-height` style set in pixels. Otherwise, the synchronization might not work properly possibly because of sub-pixel quirks.
 
 ###### Example
 
@@ -424,30 +443,135 @@ Frozen columns rely on row height synchronization between the frozen and non-fro
         line-height: 18px;
     }
 
+## Rows
+
+### Rows by Model IDs
+
+It is possible to get a table row in the Grid by the data item ID. To achieve this behavior, follow the steps below:
+
+1. Make sure the [ID field is defined in the model configuration](/api/javascript/data/model#configuration-Example) of the Grid dataSource.
+2. Retrieve the row model, the model UID, and the Grid table row consecutively:
+
+###### Example
+
+    var rowModel = gridObject.dataSource.get(10249); // get method of the Kendo UI dataSource object
+    var modelUID = rowModel.get("uid"); // get method of the Kendo UI Model object
+    var tableRow = $("[data-uid='" + modelUID + "']"); // the data-uid attribute is applied to the desired table row element. This UID is rendered by the Grid automatically.
+
+### Custom Rows When No Records Are Loaded
+
+It is possible to manually add a table row with some user-friendly message when the dataSource does not return any data&mdash;for example, as a result of filtering.
+
+The example below demonstrates how to add a table row in the [`dataBound`](/api/javascript/ui/grid#events-dataBound) event handler of the Grid.
+
+###### Example
+
+    function onGridDataBound(e) {
+        if (!e.sender.dataSource.view().length) {
+            var colspan = e.sender.thead.find("th:visible").length,
+                emptyRow = '<tr><td colspan="' + colspan + '">... no records ...</td></tr>';
+            e.sender.tbody.parent().width(e.sender.thead.width()).end().html(emptyRow);
+        }
+    }
+
+### Row Templates
+
+It is possible to format any cell within the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
+
+The example below demonstrates how to use a template to format the email address as a hyperlink by using a template declared in a script block.
+
+###### Example
+
+    <script id="template" type="text/x-kendo-tmpl">
+        <tr>
+            <td>
+                #= firstName #
+            </td>
+            <td>
+                #= lastName #
+            </td>
+            <td>
+                <a href="mailto:#= email #">#= email #</a>
+            </td>
+        </tr>
+    </script>
+
+Specify this as a template for each row by passing it in to the `rowTemplate` option on the Grid and initializing it with the `kendo.template` function, as demonstrated in the following example.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        rowTemplate: kendo.template($("#template").html()),
+       // other configuration
+    });
+
+In the resulting Grid, the email address is an interactive hyperlink which opens a new email message when clicked.
+
+**Figure 2. Grid with a row template applied**
+
+![Grid with row template](/controls/data-management/grid/grid8_1.png)
+
+For more information on using column templates, refer to the article on [remote data binding]({% slug remote_data_binding_grid %}#set-the-column-template).
+
 ## Hidden Containers
 
-Depending on the Grid configuration, the widget may need to perform JavaScript calculations to adjust its layout during initialization inside hidden containers, e.g. when scrolling, virtual scrolling, or frozen columns are used. Generally, JavaScript size calculations do not work for elements, which are hidden with a `display:none` style and the Grid can also be affected.
+If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
+
+### General Approaches
+
+Generally, consider the following approaches:
+
+* Apply [virtual scrolling]({% slug walkthrough_kendoui_grid_widget%}#virtual-scrolling) to make the vertical scrollbar disappear.
+* If you do not apply virtual scrolling, it is possible to use any of the following options:
+  * Initialize the Grid when its element becomes visible.
+  * Manually adjust the layout of the Grid. If you use an old Kendo UI version, apply the code from the previous example. You do not need to attach a `resize` handler of the window. As of Kendo UI Q3 2013 release onwards, it is possible to use the [`kendo.resize()`](/api/javascript/kendo#methods-resize) or the [`resize()`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method of the Grid.
+  * Instead of setting an overall height for the Grid in its configuration, define the height for the scrollable data area only. In this case, no height calculations are made.
+
+     ###### Example
+
+     ```
+        #GridID .k-grid-content
+        {
+            height: 270px;
+        }
+      ```
+
+  * If you use virtual scrolling and the Grid is initialized while hidden, you have to re-fetch its dataSource when the widget becomes visible. This also readjusts the height of the scrollable data area and no other configuration is required.
+
+      ###### Example
+
+      ```
+        $("#GridID").data("kendoGrid").dataSource.fetch();
+      ```
+
+### Specific Scenarios
 
 Depending on the exact scenario, the following behavior can be observed when the widget is eventually displayed:
 
 * The scrollable data area overflows the bottom border of the Grid. This can be resolved by executing the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method when the Grid becomes visible. Alternatively, apply the desired height to the scrollable data area instead of the Grid widget.
 
-###### Example
+  ###### Example
 
-        #GridID .k-grid-content
-        {
-            height: 270px;
-        }
+  ```
+    #GridID .k-grid-content
+    {
+        height: 270px;
+    }
+  ```
 
-* The virtual scrollbar is not visible. This can be resolved by executing the [`resize`](/using-kendo-in-responsive-web-pages#individual-widget-resizing) method when the Grid becomes visible. For Kendo UI Q3 2014 (2014.3.1119) release and older, apply the following statement instead of `resize()`.
+* The virtual scrollbar is not visible. It is possible to resolve this issue by executing the [`resize`](/using-kendo-in-responsive-web-pages#individual-widget-resizing) method when the Grid becomes visible. For the Kendo UI Q3 2014 (2014.3.1119) release and older, apply the following statement instead of `resize()`.
 
-###### Example
+  ###### Example
 
-        $("#GridID").data("kendoGrid").dataSource.fetch();
+  ```
+    $("#GridID").data("kendoGrid").dataSource.fetch();
+  ```
 
-* Frozen columns are too narrow and non-frozen columns are not visible. This can be resolved by executing the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method when the Grid becomes visible.
+* Frozen columns are too narrow and non-frozen columns are not visible. It is possible to resolve this issue by executing the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method when the Grid becomes visible.
 
-In some cases it may be possible to delay the initialization of the Grid, or change the order in which various Kendo UI widgets are initialized, so that the Grid is initialized while visible. For more information on how to initialize the Grid inside other Kendo UI widgets which act as hidden containers, see:
+In some cases, it might be possible to delay the initialization of the Grid, or change the order in which various Kendo UI widgets are initialized, so that the Grid is initialized while visible.
+
+For more information on how to initialize the Grid inside other Kendo UI widgets which act as hidden containers, refer to the following articles:
 
 * [Initialize the Grid inside the PanelBar]({% slug initialize_thegrid_panelbar_widget %})
 * [Initialize the Grid inside the TabStrib]({% slug initialize_thegrid_tabstrip_widget %})
@@ -457,21 +581,24 @@ In some cases it may be possible to delay the initialization of the Grid, or cha
 
 ### Hover Effect on Table Rows
 
-As of Kendo UI Q1 2016 row hover state styles are added to all Kendo UI themes. Hover is a useful UI state providing visual affordance especially across long table rows and in the editing mode of the Grid. However, there are scenarios in which the `hover` state might be misleading and is not needed.
+As of the Kendo UI Q1 2016 release, row hover state styles are added to all Kendo UI themes. Hover is a useful UI state providing visual affordance especially across long table rows and in the editing mode of the Grid. However, in some scenarios, the `hover` state might be misleading and is not recommended.
 
-There are two ways to remove the hover styling. One is to open the Kendo UI theme CSS file (e.g. `kendo.default.min.css`) and remove the following CSS rule.
+To remove the hover styling, use wither of the ways:
+* Open the Kendo UI theme CSS file (for example, `kendo.default.min.css`) and remove the CSS rule shown in the following example.
 
-###### Example
+  ###### Example
 
-    .k-grid tr:hover {
-        /* ...background styles here... */
-    }
+      ```
+      .k-grid tr:hover {
+          /* ...background styles here... */
+        }
+      ```
 
-<!--*-->
-The other option is to use the following CSS code to override the hover styling.
+* Use the CSS code shown in the following example to override the hover styling.
 
-###### Example
+  ###### Example
 
+    ```
     .k-grid tr:not(.k-state-selected):hover {
         background: none;
         color: inherit;
@@ -480,21 +607,20 @@ The other option is to use the following CSS code to override the hover styling.
     .k-grid tr.k-alt:not(.k-state-selected):hover {
         background: #f1f1f1;
     }
+    ```
 
-The `#f1f1f1` value corresponds to the background color of `.k-alt` table rows. You can find the correct value for the Kendo UI theme that you are using by using the browser's DOM inspector. Alternatively, set a background color value or your preference.
+The `#f1f1f1` value corresponds to the background color of the `.k-alt` table rows. To find the correct value for the Kendo UI theme that you are applying, use the DOM inspector of the browser. Alternatively, set a background color value of your preference.
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
+* [Remote Data Binding of the Grid]({% slug remote_data_binding_grid %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/appearance.md
+++ b/docs/controls/data-management/grid/appearance.md
@@ -189,7 +189,7 @@ When a virtualized Grid is scrolled, it renders the table rows for the reached s
 
 If the total number of items is large and the scrolling is fast, the table of the Grid can be re-rendered frequently. If, additionally, the page size is huge, the user might observe issues with the smoothness of the scrolling. In such cases, consider reducing the page size and increasing the Grid height to reduce the frequency of table re-rendering.
 
-#### Limitations of Virtual Scrolling
+#### Known Limitations
 
 * Horizontal scrolling is not virtualized.
 
@@ -445,9 +445,9 @@ Frozen columns rely on row height synchronization between the frozen and non-fro
 
 ## Rows
 
-### Rows by Model IDs
+### Model IDs
 
-It is possible to get a table row in the Grid by the data item ID. To achieve this behavior, follow the steps below:
+It is possible to get a table row in the Grid by the ID of the data item. To achieve this behavior, follow the steps below:
 
 1. Make sure the [ID field is defined in the model configuration](/api/javascript/data/model#configuration-Example) of the Grid dataSource.
 2. Retrieve the row model, the model UID, and the Grid table row consecutively:

--- a/docs/controls/data-management/grid/appearance.md
+++ b/docs/controls/data-management/grid/appearance.md
@@ -480,61 +480,41 @@ For more information on using row templates, refer to the [walkthrough article](
 
 ## Hidden Containers
 
-If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
+If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript size calculations do not work for elements with a `display:none` style.
 
-### General Approaches
+### Symptoms
 
-Generally, consider the following approaches:
+The following behaviors can be observed if the Grid is initialized while hidden:
 
-* Apply [virtual scrolling]({% slug walkthrough_kendoui_grid_widget%}#virtual-scrolling) to make the vertical scrollbar disappear.
-* If you do not apply virtual scrolling, it is possible to use any of the following options:
-  * Initialize the Grid when its element becomes visible.
-  * Manually adjust the layout of the Grid. If you use an old Kendo UI version, apply the code from the previous example. You do not need to attach a `resize` handler of the window. As of Kendo UI Q3 2013 release onwards, it is possible to use the [`kendo.resize()`](/api/javascript/kendo#methods-resize) or the [`resize()`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method of the Grid.
-  * Instead of setting an overall height for the Grid in its configuration, define the height for the scrollable data area only. In this case, no height calculations are made.
+* The Grid may appear smaller than expected.
+* The scrollable data area overflows the bottom border of the Grid.
+* If [virtual scrolling]({% slug walkthrough_kendoui_grid_widget%}#virtual-scrolling) is enabled, the vertical scrollbar is not visible.
+* Frozen columns are too narrow and non-frozen columns are not visible.
 
-     ###### Example
+### Solutions
 
-     ```
-        #GridID .k-grid-content
-        {
-            height: 270px;
-        }
-      ```
+* Delay the initialization of the Grid or change the order in which various Kendo UI widgets are initialized, so that the Grid is initialized after its element becomes visible.
 
-  * If you use virtual scrolling and the Grid is initialized while hidden, you have to re-fetch its dataSource when the widget becomes visible. This also readjusts the height of the scrollable data area and no other configuration is required.
+* Execute the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method of the Grid after the widget becomes visible.
 
-      ###### Example
+* Instead of setting an overall height for the Grid in its configuration, define the height for the scrollable data area only. In this case, no height calculations are made. This approach is applicable only if frozen columns and virtual scrolling are _not_ used.
 
-      ```
-        $("#GridID").data("kendoGrid").dataSource.fetch();
-      ```
+    ###### Example
 
-### Specific Scenarios
+    ```
+      #GridID .k-grid-content
+      {
+          height: 270px;
+      }
+    ```
 
-Depending on the exact scenario, the following behavior can be observed when the widget is eventually displayed:
+* Fetch the data source instead of calling the `resize()` method. This approach is applicable if virtual scrolling is enabled and the Kendo UI version is older than 2014.3.1119.
 
-* The scrollable data area overflows the bottom border of the Grid. This can be resolved by executing the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method when the Grid becomes visible. Alternatively, apply the desired height to the scrollable data area instead of the Grid widget.
+    ###### Example
 
-  ###### Example
-
-  ```
-    #GridID .k-grid-content
-    {
-        height: 270px;
-    }
-  ```
-
-* The virtual scrollbar is not visible. It is possible to resolve this issue by executing the [`resize`](/using-kendo-in-responsive-web-pages#individual-widget-resizing) method when the Grid becomes visible. For the Kendo UI Q3 2014 (2014.3.1119) release and older, apply the following statement instead of `resize()`.
-
-  ###### Example
-
-  ```
+    ```
     $("#GridID").data("kendoGrid").dataSource.fetch();
-  ```
-
-* Frozen columns are too narrow and non-frozen columns are not visible. It is possible to resolve this issue by executing the [`resize`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method when the Grid becomes visible.
-
-In some cases, it might be possible to delay the initialization of the Grid, or change the order in which various Kendo UI widgets are initialized, so that the Grid is initialized while visible.
+    ```
 
 For more information on how to initialize the Grid inside other Kendo UI widgets which act as hidden containers, refer to the following articles:
 

--- a/docs/controls/data-management/grid/appearance.md
+++ b/docs/controls/data-management/grid/appearance.md
@@ -476,42 +476,7 @@ The example below demonstrates how to add a table row in the [`dataBound`](/api/
 
 ### Row Templates
 
-It is possible to format any cell within the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
-
-The example below demonstrates how to use a template to format the email address as a hyperlink by using a template declared in a script block.
-
-###### Example
-
-    <script id="template" type="text/x-kendo-tmpl">
-        <tr>
-            <td>
-                #= firstName #
-            </td>
-            <td>
-                #= lastName #
-            </td>
-            <td>
-                <a href="mailto:#= email #">#= email #</a>
-            </td>
-        </tr>
-    </script>
-
-Specify this as a template for each row by passing it in to the `rowTemplate` option on the Grid and initializing it with the `kendo.template` function, as demonstrated in the following example.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        rowTemplate: kendo.template($("#template").html()),
-       // other configuration
-    });
-
-In the resulting Grid, the email address is an interactive hyperlink which opens a new email message when clicked.
-
-**Figure 2. Grid with a row template applied**
-
-![Grid with row template](/controls/data-management/grid/grid8_1.png)
-
-For more information on using column templates, refer to the article on [remote data binding]({% slug remote_data_binding_grid %}#set-the-column-template).
+For more information on using row templates, refer to the [walkthrough article]({% slug walkthrough_kendoui_grid_widget %}#templates).
 
 ## Hidden Containers
 

--- a/docs/controls/data-management/grid/data-binding.md
+++ b/docs/controls/data-management/grid/data-binding.md
@@ -11,13 +11,13 @@ position: 3
 
 The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) features a rapid templating engine and a built-in dataSource, which allow you to set up the widget very quickly and use it in your project.
 
-## Bind to Remote Data
+## The Procedure
 
-To start with, we need a data source. Due to my work on [instasharp.org](http://instasharp.org/) recently, I have become quite familiar with the Instagram API. We can use their "Popular" feeds endpoint without having to go through an authorization process. We still need a client_id, but it is easy to sign up for one of those at [http://instagram.com/developer/register/#](http://instagram.com/developer/register/#).
+To bind the Grid to remote data, provide the data source. For the sake of demonstrating the approach, the examples in this article use the **Popular** feeds endpoint  of the Instagram API. To sign up for a `client_id`, use [this link](http://instagram.com/developer/register/#).
 
-### Supply Remote Endpoint
+### Supply the Remote Endpoint
 
-Kendo UI provides a very powerful [data binding framework](http://demos.telerik.com/kendo-ui/datasource/index) you can use right inline with your grid. To do that, define the data source of the grid and supply your remote endpoint.
+Kendo UI provides a powerful [data binding framework](http://demos.telerik.com/kendo-ui/datasource/index) that can be used inline with the Grid. To do that, define the data source of the widget and supply the remote endpoint.
 
 ###### Example
 
@@ -62,20 +62,21 @@ Kendo UI provides a very powerful [data binding framework](http://demos.telerik.
         });
 
     </script>   
-
 ```
 
-For a better understanding of the example above, refer to the following explanations:
+**Explanation of the previous example**
 
-* `dataSource` - creates a new Kendo UI data source and assigns it as the data source for the Grid.
-* `transport` - defines how you will communicate with your remote data source.
-* `url` - points the location of the data you want to bind the widget to.
-* `dataType` - tells the data source the format you expect the response to be in. In this case, it is JSONP. JSONP is a way of returning JSON from a cross-browser request without getting blocked. It is also a way to get malicious code injected into your page. It basically wraps the JSON response in a callback to intentionally mislead the browser. It is recommended not to do it unless you fully trust your data.
-* `schema` - tells the Grid what the schema of your response is. Think of it as the "JSON element to repeat on". Kendo UI looks for this element to represent each row in the Grid. The server returns an array of `data` elements so your repeating item is just `"data"`.
+* The `dataSource` creates a new Kendo UI data source and assigns it as the data source for the Grid.
+* The `transport` defines the way you will communicate with the remote data source.
+* The `url` points the location of the data you want to bind the widget to.
+* The `dataType` indicates the format of the response in which the data source is expected to be&mdash;JSONP in the example. JSONP is a way of returning JSON from a cross-browser request without getting blocked. It is also a way to get malicious code injected into the page. It basically wraps the JSON response in a callback to intentionally mislead the browser. It is not recommended to do so unless you fully trust your data.
+* The `schema` indicates to the Grid what the schema of the response is. It functions as the JSON element to repeat on&mdash;Kendo UI looks for this element to represent each row in the Grid. The server returns an array of `data` elements so the repeating item is `"data"`.
 
-### Add Data
+### Add the Data
 
-When you run the example, you see a grid with no data in it. Therefore, you must provide the Grid with the data you want to be rendered in each column. Do this by specifying which element off the `data` tag in the server response you want to show in that particular column. The next example specifies the `field` attribute in the column array, so that the Grid displays the actual data from your response.
+The previous example renders a Grid without any data in it. To provide the widget with the data for each column, specify which element of the `data` tag in the server response has to be shown in each particular column.
+
+The example below demonstrates how to specify the `field` attribute in the column array in such a way that the Grid displays the actual data from the response.
 
 ###### Example
 
@@ -127,7 +128,9 @@ When you run the example, you see a grid with no data in it. Therefore, you must
 
 ### Handle Visualization
 
-Now you have some data as well as some issues with its visualization. The Grid renders the URL of an image in its **Image** column and the other columns show arrays of objects. Now you need indicate to the Grid that the way you want it to display each of the columns. Do this by an inline template for the image, as demonstrated below.
+The Grid renders the URL of an image in its **Image** column and the other columns show arrays of objects.
+
+The example below demonstrates how to indicate to the Grid the way you want the widget to display each of the columns by using an inline template for the image.
 
 ###### Example
 
@@ -177,11 +180,11 @@ Now you have some data as well as some issues with its visualization. The Grid r
     </script>
 ```
 
-### Set Column Template
+### Set the Column Template
 
-The rest of the columns need some more specific templating since they are complex displays, not single fields. You can do that by moving the template outside of the Grid and then setting the template for the details to contain the name of the user that created the photo, the filter they used to create it, and the photo caption. In the last cell, use JavaScript in your templates to enumerate over the comments to display them in a list.
+The rest of the columns need additional specific templating because they are complex displays and not single fields. To configure the columns, move the template outside the Grid and set the template for the details to contain the name of the user who created the photo, the filter they used to create it, and the photo caption. To enumerate the comments and display them in a list, use JavaScript in the template in the last cell. All markup is now removed from the JavaScript.
 
-All markup is now removed from your JavaScript. Add some style, as demonstrated in the example below, so that you fully customize the Grid.
+The example below demonstrates how to fully customize the Grid by applying additional styles to it.
 
 ###### Example
 
@@ -285,20 +288,18 @@ All markup is now removed from your JavaScript. Add some style, as demonstrated 
 
 > **Important**  
 >
-> When you check out the `html` code in the above example, you see the templating syntax for [Kendo UI templates](/framework/templates/overview). Templates represent HTML content inside of special script blocks. Note that JavaScript is also mixed right along with the `html` content. The syntax is familiar to the one used when doing PHP, Razor, or other server-side templating engine.
+> The `html` code in the previous example displays special script blocks which contain the templating syntax for the [Kendo UI templates]({% slug overview_kendoui_templatescomponent %}). The JavaScript that is used is also mixed with the `html` content and the syntax of the templates is similar to the syntax that is applied in the creation of a PHP, Razor, or other server-side templating engine.
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/editing.md
+++ b/docs/controls/data-management/grid/editing.md
@@ -8,13 +8,13 @@ position: 4
 
 # Editing
 
-Editing is one of the basic functionalities Kendo UI Grid supports and it allows you to manipulate the way the data is presented.
+Editing is one of the basic functionalities the Kendo UI Grid supports. It allows you to manipulate the way the data is presented.
 
 ## Setup
 
-To enable the editing support for the Kendo UI Grid widget, perform the steps described below.
+To enable the editing support for the Grid, perform the steps described below.
 
-### Configure DataSource
+### Configure the Data Source
 
 The example below demonstrates how to configure the dataSource for CRUD (Create, Read, Update, Destroy) data operations.
 
@@ -41,7 +41,7 @@ The example below demonstrates how to configure the dataSource for CRUD (Create,
          //...
     });
 
-### Define Fields: schema
+### Define Fields through schema
 
 The example below demonstrates how to declare fields definitions through the DataSource `schema`.
 
@@ -79,7 +79,7 @@ The example below demonstrates how to declare fields definitions through the Dat
       }
     });
 
-### Set Options: editable
+### Set the editable Option
 
 The example below demonstrates the two alternatives to set the `editable` configuration option in the Grid.
 
@@ -100,7 +100,7 @@ The example below demonstrates the two alternatives to set the `editable` config
           }
     });
 
-If you want to enable the insertion of new records, configure the Toolbar, as shown below.
+To enable the insertion of new records, configure the Toolbar, as demonstrated in the following example.
 
 ###### Example
 
@@ -110,7 +110,7 @@ If you want to enable the insertion of new records, configure the Toolbar, as sh
          editable: true
     });
 
-If you want to delete records, define a delete command column, as demonstrated below.
+To delete records, define a delete command column, as demonstrated in the following example.
 
 ###### Example
 
@@ -126,20 +126,24 @@ If you want to delete records, define a delete command column, as demonstrated b
          editable: true
      });
 
-## Editing of Foreign Key Columns
+## Foreign Key Columns
 
-Normally, a foreign key column should be bound to a numeric data field, which points to the unique keys of a separate collection. An issue related to editing may occur if some of the values in the foreign key column are `null`. While this will not create problems in display mode, it will mislead the column editor to think it should work with object values, instead of primitive values. As a result, when a value is picked from the DropDownList, the widget will set an object value to the Grid data item (e.g. {text: "Foo", value: 3} ), instead of a numeric value (e.g. 3). This will cause the Grid cell to remain blank upon exiting edit mode.
+Normally, a foreign key column is bound to a numeric data field, which points to the unique keys of a separate collection.
 
-To avoid the above behavior, one of the following options paths be followed:
+If some of the values in the foreign key column are `null`, an issue related to editing might occur. While this does not create problems in display mode, it misleads the column editor by causing it to perceive it has to work with object values instead of primitive values. As a result, when a value is picked from the DropDownList, the widget sets an object value to the data item of the Grid (for example, `{text: "Foo", value: 3}`), instead of a numeric value (for example, `3`). This causes the Grid cell to remain blank upon exiting edit mode.
 
-* Use zeros instead of nulls to match the data values to the declared data field type.
-* Use a [custom column Editor](http://demos.telerik.com/kendo-ui/grid/editing-custom) with manually configured DropDownList that has a [`valuePrimitive`](/api/javascript/ui/dropdownlist#configuration-valuePrimitive) setting set to `true`.
+To avoid this behavior, consider any of the following options:
 
-## Using Custom Editors
+* Use zeros instead of nulls to match the data values with the declared data field type.
+* Use a [custom column editor](http://demos.telerik.com/kendo-ui/grid/editing-custom) with manually configured DropDownList that has a [`valuePrimitive`](/api/javascript/ui/dropdownlist#configuration-valuePrimitive) setting set to `true`.
 
-When a Kendo UI MultiSelect is used as a custom editor, the `save` event of the Grid is not triggered when the value of the MultiSelect is changed.
+## Custom Editors
 
-The reason for this is that the value of the MultiSelect is a reference type&mdash;`array`&mdash;which prevents the normal usage of the `model.set()` function for setting the value of the corresponding model property. To work around this behavior, define a custom data-binding mechanism. After applying this fix, the `save` event of the Grid will be triggered properly each time a new selection is added to the value of the MultiSelect.
+When a Kendo UI MultiSelect is used as a custom editor in the Grid and the value of the MultiSelect is changed, the `save` event of the Grid is not triggered.
+
+The reason for this is that the value of the MultiSelect is a reference type (`array`), which prevents the normal usage of the `model.set()` function for setting the value of the corresponding model property.
+
+To work around this behavior, define a custom data-binding mechanism. After applying this fix, the `save` event of the Grid is properly triggered each time a new selection is added to the value of the MultiSelect.
 
 To see the runnable example on this issue, refer to the article on [using the MultiSelect as a custom editor in the Grid]({% slug howto_usemultiselectascustomeditor_grid %}).
 

--- a/docs/controls/data-management/grid/editing.md
+++ b/docs/controls/data-management/grid/editing.md
@@ -145,16 +145,13 @@ To see the runnable example on this issue, refer to the article on [using the Mu
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/excel-export.md
+++ b/docs/controls/data-management/grid/excel-export.md
@@ -303,16 +303,13 @@ Internet Explorer 9 and Safari do not support the option for saving a file and r
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/excel-export.md
+++ b/docs/controls/data-management/grid/excel-export.md
@@ -158,22 +158,6 @@ The [`excelExport`](/api/javascript/ui/grid#events-excelExport) event allows rev
     </script>
 ```
 
-### Column Templates
-
-The Grid does not use [column templates](/api/javascript/ui/grid#configuration-columns.template) during the Excel export&mdash;it exports only the data. The reason for this behavior is that a column template might contain arbitrary HTML which cannot be converted to Excel column values. For more information on how to use a column template that does not contain HTML, refer to [this column template example]({% slug howto_use_column_template_grid %}).
-
-### Column Format
-
-The Grid does not use [column formats](/api/javascript/ui/grid.html#configuration-columns.format) during the Excel export because some Kendo UI formats are incompatible with Excel. To format the cell values, set the [`format`](/api/javascript/ooxml/workbook.html#configuration-sheets.rows.cells.format) option of the cells.
-
-For more information on the formats that are supported by Excel, refer to [this page](https://support.office.com/en-us/article/Create-a-custom-number-format-78f2a361-936b-4c03-8772-09fab54be7f4).
-
-For more information on how to format cell values, refer to [this example]({% slug howto_format_cell_values_grid %}).
-
-### Detail Template
-
-The Grid does not export its [detail template](/api/javascript/ui/grid#configuration-detailTemplate) for the same reason as it does not export its column templates. If the detail template contains another Grid, follow [the example on the exporting a detail Grid]({% slug howto_exportto_excel_masterand_detail_grid %}).
-
 ### Row Type
 
 Each row has a `type` field that can be used to distinguish between the various row types in the Grid.
@@ -231,6 +215,24 @@ The example below demonstrates how to post files to the server.
             }
         });
     </script>
+
+### Limitations
+
+#### Column Templates
+
+The Grid does not use [column templates](/api/javascript/ui/grid#configuration-columns.template) during the Excel export&mdash;it exports only the data. The reason for this behavior is that a column template might contain arbitrary HTML which cannot be converted to Excel column values. For more information on how to use a column template that does not contain HTML, refer to [this column template example]({% slug howto_use_column_template_grid %}).
+
+#### Column Format
+
+The Grid does not use [column formats](/api/javascript/ui/grid.html#configuration-columns.format) during the Excel export because some Kendo UI formats are incompatible with Excel. To format the cell values, set the [`format`](/api/javascript/ooxml/workbook.html#configuration-sheets.rows.cells.format) option of the cells.
+
+For more information on the formats that are supported by Excel, refer to [this page](https://support.office.com/en-us/article/Create-a-custom-number-format-78f2a361-936b-4c03-8772-09fab54be7f4).
+
+For more information on how to format cell values, refer to [this example]({% slug howto_format_cell_values_grid %}).
+
+#### Detail Templates
+
+The Grid does not export its [detail template](/api/javascript/ui/grid#configuration-detailTemplate) for the same reason as it does not export its column templates. If the detail template contains another Grid, follow [the example on the exporting a detail Grid]({% slug howto_exportto_excel_masterand_detail_grid %}).
 
 ## Server-Side Processing
 

--- a/docs/controls/data-management/grid/how-to/Editing/grid-localstorage-crud.md
+++ b/docs/controls/data-management/grid/how-to/Editing/grid-localstorage-crud.md
@@ -2,6 +2,7 @@
 title: Perform CRUD Operations with Local Storage Data
 page_title: Perform CRUD Operations with Local Storage Data | Kendo UI Grid
 description: "Learn how to perform CRUD operations with local storage data in the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/grid-localstorage-crud
 slug: howto_perform_crud_operationswith_local_storage_data_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/Editing/reorder-rows-nested-grids.md
+++ b/docs/controls/data-management/grid/how-to/Editing/reorder-rows-nested-grids.md
@@ -1,13 +1,14 @@
 ---
-title: Reorder Rows in Grids Using Sortable
-page_title: Reorder Rows in Grids Using Sortable | Kendo UI Grid
-description: "Learn how to use the Kendo UI Sortable widget with a Kendo UI Grid either in editable or non-editable modes."
-slug: howto_usegridandsortable_grid
+title: Reorder Rows in Nested Grids Using Sortable
+page_title: Reorder Rows in Nested Grids Using Sortable | Kendo UI Grid
+description: "Learn how to reorder rows in a child Grid using the Kendo UI Sortable widget."
+previous_url: /controls/data-management/grid/how-to/reorder-rows-nested-grids
+slug: howto_reorderrowsinnestedgrid_grid
 ---
 
-# Reorder Rows in Grids Using Sortable
+# Reorder Rows in Nested Grids Using Sortable
 
-To see the examples on how to use the Kendo UI Sortable widget with a Kendo UI Grid either in an editable or in a non-editable mode, refer to [this how-to article]({% slug howto_usesortablewithgrid_inincellediting_sortable %}).
+To see the example on how to reorder rows in a child Kendo UI Grid using the Kendo UI Sortable widget, refer to [this how-to article]({% slug howto_reorderrowsinnestedgrid_sortable %}).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/how-to/Editing/show-progress-CRUD-operation.md
+++ b/docs/controls/data-management/grid/how-to/Editing/show-progress-CRUD-operation.md
@@ -2,6 +2,7 @@
 title: Show Progress for Grid CRUD Operations
 page_title: Show Progress for Grid CRUD Operations | Kendo UI Grid
 description: "Learn how to show the current progress of each CRUD operation for a Kendo UI Grid."
+previous_url: /controls/data-management/grid/how-to/show-progress-CRUD-operation
 slug: howto_show_progress_CRUD_operation
 ---
 

--- a/docs/controls/data-management/grid/how-to/Editing/use-grid-sortable-reorder.md
+++ b/docs/controls/data-management/grid/how-to/Editing/use-grid-sortable-reorder.md
@@ -1,13 +1,14 @@
 ---
-title: Reorder Rows in Nested Grids Using Sortable
-page_title: Reorder Rows in Nested Grids Using Sortable | Kendo UI Grid
-description: "Learn how to reorder rows in a child Grid using the Kendo UI Sortable widget."
-slug: howto_reorderrowsinnestedgrid_grid
+title: Reorder Rows in Grids Using Sortable
+page_title: Reorder Rows in Grids Using Sortable | Kendo UI Grid
+description: "Learn how to use the Kendo UI Sortable widget with a Kendo UI Grid either in editable or non-editable modes."
+previous_url: /controls/data-management/grid/how-to/use-grid-sortable-reorder
+slug: howto_usegridandsortable_grid
 ---
 
-# Reorder Rows in Nested Grids Using Sortable
+# Reorder Rows in Grids Using Sortable
 
-To see the example on how to reorder rows in a child Kendo UI Grid using the Kendo UI Sortable widget, refer to [this how-to article]({% slug howto_reorderrowsinnestedgrid_sortable %}).
+To see the examples on how to use the Kendo UI Sortable widget with a Kendo UI Grid either in an editable or in a non-editable mode, refer to [this how-to article]({% slug howto_usesortablewithgrid_inincellediting_sortable %}).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/how-to/Layout/cell-color-based-on-foreignkey-values.md
+++ b/docs/controls/data-management/grid/how-to/Layout/cell-color-based-on-foreignkey-values.md
@@ -2,6 +2,7 @@
 title: Set Cell Color Based on ForeignKey Values
 page_title: Set Cell Color Based on ForeignKey Values | Kendo UI Grid
 description: "Learn how to create custom a custom editor in a Kendo UI Grid detail template."
+previous_url: /controls/data-management/grid/how-to/cell-color-based-on-foreignkey-values
 slug: howto_set_cell_color_basedon_foreignkey_values_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/Layout/grid-with-kendo-ui-tooltip.md
+++ b/docs/controls/data-management/grid/how-to/Layout/grid-with-kendo-ui-tooltip.md
@@ -2,7 +2,7 @@
 title: Show Tooltip for Column Records
 page_title: Show Tooltip for Column Records | Kendo UI Grid
 description: "Learn how to show Kendo UI Tooltip for Kendo UI Grid columns."
-previous_url: /controls/data-management/grid/how-to/add-tooltip-for-cell
+previous_url: /controls/data-management/grid/how-to/add-tooltip-for-cell, /controls/data-management/grid/how-to/grid-with-kendo-ui-tooltip
 slug: howto_show_tooltipfor_column_records_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/Layout/style-rows-cells-based-on-data-item-values.md
+++ b/docs/controls/data-management/grid/how-to/Layout/style-rows-cells-based-on-data-item-values.md
@@ -2,6 +2,7 @@
 title: Customize Rows and Cells Based on Data Item Values
 page_title: Customize Rows and Cells Based on Data Item Values | Kendo UI Grid
 description: "Learn how to customize kendo UI Grid cells and rows, based on data items values."
+previous_url: /controls/data-management/grid/how-to/style-rows-cells-based-on-data-item-values, /controls/data-management/grid/how-to/style-rows-cells-based-on-data-item-values
 slug: howto_customize_rowsand_cells_basedon_dataitem_values_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/Templates/data-attribute-initialization-with-detail-template.md
+++ b/docs/controls/data-management/grid/how-to/Templates/data-attribute-initialization-with-detail-template.md
@@ -2,6 +2,7 @@
 title: Initialize Data Attribute with Detail Template
 page_title: Initialize Data Attribute with Detail Template | Kendo UI Grid
 description: "Learn how to initialize a Kendo UI Grid widget by using data attributes and including a detail template."
+orevious_url: /controls/data-management/grid/how-to/data-attribute-initialization-with-detail-template
 slug: howto_initialize_data_attributewith_detail_template_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/binding/bind-grid-to-xml-data.md
+++ b/docs/controls/data-management/grid/how-to/binding/bind-grid-to-xml-data.md
@@ -1,13 +1,14 @@
 ---
-title: Initialize the Grid in Window
-page_title: Initialize the Grid in Window | Kendo UI Grid
-description: "Learn how to initialize a Kendo UI Grid inside a Kendo UI Window widget by resizing it according to the dimensions of its container."
-slug: howto_initializegridinwindow_grid
+title: Bind to XML Data
+page_title: Bind to XML Data | Kendo UI Grid
+description: "Learn how to bind a Kendo UI Grid to XML data."
+previous_url: /controls/data-management/grid/how-to/bind-grid-to-xml-data.html
+slug: howto_bindgridtoxmldata_grid
 ---
 
-# Initialize the Grid in Window
+# Bind to XML Data
 
-To see the example on how to use the `activate` event when initializing a Grid within a Window so that it is resized according to the dimensions of its container, refer to [this how-to article]({% slug initialize_thegrid_window_widget %}).
+To see the example on how to bind a Kendo UI Grid to XML data, refer to [this project](https://github.com/telerik/ui-for-aspnet-mvc-examples/tree/master/grid/grid-bound-to-xml-data).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/how-to/binding/load-and-append-records.md
+++ b/docs/controls/data-management/grid/how-to/binding/load-and-append-records.md
@@ -2,6 +2,7 @@
 title: Load and Append More Records While Scrolling Down
 page_title: Load and Append More Records While Scrolling Down | Kendo UI Grid
 description: "Learn how to load and append more records as the user scrolls down the Kendo UI Grid."
+previous_url: /controls/data-management/grid/how-to/load-and-append-records
 slug: howto_loadand_append_morerecords_while_scrollingdown_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/binding/toolbar-mvvm-binding.md
+++ b/docs/controls/data-management/grid/how-to/binding/toolbar-mvvm-binding.md
@@ -2,6 +2,7 @@
 title: Update Toolbar Content Using MVVM Binding
 page_title: Update Toolbar Content Using MVVM Binding | Kendo UI Grid
 description: "Learn how to create a custom MVVM binding to update the Toolbar content dynamically in the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/toolbar-mvvm-binding
 slug: howto_update_toolbar_content_using_mvvmbinding_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/binding/use-nested-model-properties.md
+++ b/docs/controls/data-management/grid/how-to/binding/use-nested-model-properties.md
@@ -2,6 +2,7 @@
 title: Use Nested Model Properties
 page_title: Use Nested Model Properties | Kendo UI Grid
 description: "Learn how to use use nested model properties in the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/use-nested-model-properties
 slug: howto_use_nested_model_properties_grid
 ---
 
@@ -14,7 +15,7 @@ The example below demonstrates how to use nested model properties. CRUD operatio
 ```html
     <div id="grid"></div>
     <script>
-      function getData(length, delay) {
+      function getData(length) {
         var data = [];
         var sampleDate = new Date();
         for (var j = 1; j <= length; j++) {
@@ -27,25 +28,13 @@ The example below demonstrates how to use nested model properties. CRUD operatio
             bdate: new Date(sampleDate.getTime() - j * 1000 * 60 * 60 * 24)
           }
         }
-        return {
-          json: JSON.stringify({
-            data: data
-          }),
-          delay: delay
-        };
+        return data;
       }
 
       $("#grid").kendoGrid({
         dataSource: {
-          transport: {
-            read: {
-              url: "/echo/json/",
-              type: "post",
-              data: getData(10, 1)
-            }
-          },
+          data: getData(10),
           schema: {
-            data: "data",
             model: {
               id: "id",
               fields: {

--- a/docs/controls/data-management/grid/how-to/binding/web-api-server-operations.md
+++ b/docs/controls/data-management/grid/how-to/binding/web-api-server-operations.md
@@ -2,6 +2,7 @@
 title: Use WebAPI with Server-Side Operations
 page_title: Use WebAPI with Server-Side Operations | Kendo UI Grid
 description: "Learn how to implement the server-side data operations of paging, sorting, and filtering with WebAPI and Kendo UI Grid."
+previous_url: controls/data-management/grid/how-to/web-api-server-operations
 slug: howto_use_webapi_withserverside_operations_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/excel/copy-from-excel-to-grid.md
+++ b/docs/controls/data-management/grid/how-to/excel/copy-from-excel-to-grid.md
@@ -2,6 +2,7 @@
 title: Copy Data from Excel
 page_title: Copy Data from Excel | Kendo UI Grid
 description: "Learn how to copy data from Excel in a Kendo UI Grid."
+previous_url: /controls/data-management/grid/how-to/copy-from-excel-to-grid.html
 slug: howto_copy_datafrom_excel_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/checkbox-filter-menu.md
+++ b/docs/controls/data-management/grid/how-to/filtering/checkbox-filter-menu.md
@@ -2,6 +2,7 @@
 title: Create Checkbox Filter Menu
 page_title: Create Checkbox Filter Menu | Kendo UI Grid
 description: "Learn how to create a checkbox filter menu functionality in the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/checkbox-filter-menu.html
 slug: howto_create_checkbox_filter_menu_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/filter-by-date.md
+++ b/docs/controls/data-management/grid/how-to/filtering/filter-by-date.md
@@ -2,6 +2,7 @@
 title: Filter by Date Only
 page_title: Filter by Date Only | Kendo UI Grid
 description: "Learn how to filter date columns in the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/filter-by-date.html
 slug: howto_filter_date_columns_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/grid-filter-as-you-type.md
+++ b/docs/controls/data-management/grid/how-to/filtering/grid-filter-as-you-type.md
@@ -2,6 +2,7 @@
 title: Filter Grid as You Type
 page_title: Filter Grid as You Type | Kendo UI Grid
 description: "Learn how to filter Kendo UI Grid on the fly, as the user types in the filter row textbox."
+previous_url: /controls/data-management/grid/how-to/grid-filter-as-you-type.html
 slug: howto_filter_gridas_you_type_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/multiselect-used-for-column-filtering.md
+++ b/docs/controls/data-management/grid/how-to/filtering/multiselect-used-for-column-filtering.md
@@ -2,7 +2,7 @@
 title: Use MultiSelect for Column Filtering
 page_title: Use MultiSelect for Column Filtering | Kendo UI Grid
 description: "Learn how to use Kendo UI MultiSelect for column filtering in the Kendo UI Grid widget."
-previous_url: /controls/data-management/grid/how-to/filtering-array-column-using-multiselect
+previous_url: /controls/data-management/grid/how-to/filtering-array-column-using-multiselect, /controls/data-management/grid/how-to/multiselect-used-for-column-filtering.html 
 slug: howto_use_multiselect_forcolumn_filtering_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/sort-multi-checkbox-filter.md
+++ b/docs/controls/data-management/grid/how-to/filtering/sort-multi-checkbox-filter.md
@@ -2,6 +2,7 @@
 title: Sort Multiple Checkbox Filter
 page_title: Sort Multiple Checkbox Filter | Kendo UI Grid
 description: "Learn how to sort the Kendo UI multiple checkbox filter while using the Kendo UI Grid widget."
+previous_url: /controls/data-management/grid/how-to/sort-multi-checkbox-filter
 slug: howto_sort_multiple_checkbox_filter_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/filtering/use-filtering-with-dynamic-default-values.md
+++ b/docs/controls/data-management/grid/how-to/filtering/use-filtering-with-dynamic-default-values.md
@@ -2,6 +2,7 @@
 title: Use Grid Filtering with Dynamic Default Values
 page_title: Use Grid Filtering with Dynamic Default Values | Kendo UI Grid Widget
 description: "Learn how to use dynamic default field values in a Kendo UI Grid when filtering is applied."
+previous_url: /controls/data-management/grid/how-to/use-filtering-with-dynamic-default-values.html
 slug: howto_gridfiltering_dynamicdefaultvalues_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-panelbar.md
+++ b/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-panelbar.md
@@ -1,0 +1,24 @@
+---
+title: Initialize the Grid in PanelBar
+page_title: Initialize the Grid in PanelBar | Kendo UI Grid
+description: "Learn how to initialize a Kendo UI Grid inside a Kendo UI PanelBar widget by resizing it according to the dimensions of its container."
+slug: howto_initializegridinpanelbar_grid
+---
+
+# Initialize the Grid in PanelBar
+
+To see the example on how to use the `activate` event when initializing a Grid within a PanelBar so that it is resized according to the dimensions of its container, refer to [this how-to article]({% slug initialize_thegrid_panelbar_widget %}).
+
+## See Also
+
+Other articles and how-to examples on the Kendo UI Grid:
+
+* [JavaScript API Reference](/api/javascript/ui/grid)
+* [How to Bind to Telerik Backend Services]({% slug howto_bindto_telerik_backend_services_grid %})
+* [How to Change Languages Dynamically]({% slug howto_dynamic_language_change %})
+* [How to Create Custom ToolBar Templates]({% slug howto_create_custom_toolbar_templates_grid %})
+* [How to Create Custom Edit Buttons]({% slug howto_create_custom_edit_buttons_grid %})
+* [How to Use Resize Columns from a Button]({% slug howto_resize_columnsfrom_abutton_grid %})
+* [How to Use AngularJS in Popup Editor Templates]({% slug howto_use_angularin_popup_editor_templates_grid %})
+
+For more runnable examples on the Kendo UI Grid, browse its [**How To** documentation folder]({% slug howto_dynamic_language_change %}).

--- a/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-tabstrip.md
+++ b/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-tabstrip.md
@@ -1,0 +1,24 @@
+---
+title: Initialize the Grid in TabStrip
+page_title: Initialize the Grid in TabStrip | Kendo UI Grid
+description: "Learn how to initialize a Kendo UI Grid inside a Kendo UI TabStrip widget by resizing it according to the dimensions of its container."
+slug: howto_initializegridintabstrip_grid
+---
+
+# Initialize the Grid in TabStrip
+
+To see the example on how to use the `activate` event when initializing a Grid within a TabStrip so that it is resized according to the dimensions of its container, refer to [this how-to article]({% slug overview_kendoui_tabstrip_widget %}).
+
+## See Also
+
+Other articles and how-to examples on the Kendo UI Grid:
+
+* [JavaScript API Reference](/api/javascript/ui/grid)
+* [How to Bind to Telerik Backend Services]({% slug howto_bindto_telerik_backend_services_grid %})
+* [How to Change Languages Dynamically]({% slug howto_dynamic_language_change %})
+* [How to Create Custom ToolBar Templates]({% slug howto_create_custom_toolbar_templates_grid %})
+* [How to Create Custom Edit Buttons]({% slug howto_create_custom_edit_buttons_grid %})
+* [How to Use Resize Columns from a Button]({% slug howto_resize_columnsfrom_abutton_grid %})
+* [How to Use AngularJS in Popup Editor Templates]({% slug howto_use_angularin_popup_editor_templates_grid %})
+
+For more runnable examples on the Kendo UI Grid, browse its [**How To** documentation folder]({% slug howto_dynamic_language_change %}).

--- a/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-window.md
+++ b/docs/controls/data-management/grid/how-to/hidden/initiliaze-in-window.md
@@ -1,13 +1,14 @@
 ---
-title: Bind to XML Data
-page_title: Bind to XML Data | Kendo UI Grid
-description: "Learn how to bind a Kendo UI Grid to XML data."
-slug: howto_bindgridtoxmldata_grid
+title: Initialize the Grid in Window
+page_title: Initialize the Grid in Window | Kendo UI Grid
+description: "Learn how to initialize a Kendo UI Grid inside a Kendo UI Window widget by resizing it according to the dimensions of its container."
+previous_url: /controls/data-management/grid/how-to/initiliaze-in-window.html
+slug: howto_initializegridinwindow_grid
 ---
 
-# Bind to XML Data
+# Initialize the Grid in Window
 
-To see the example on how to bind a Kendo UI Grid to XML data, refer to [this project](https://github.com/telerik/ui-for-aspnet-mvc-examples/tree/master/grid/grid-bound-to-xml-data).
+To see the example on how to use the `activate` event when initializing a Grid within a Window so that it is resized according to the dimensions of its container, refer to [this how-to article]({% slug initialize_thegrid_window_widget %}).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/how-to/state/persist-expanded-rows.md
+++ b/docs/controls/data-management/grid/how-to/state/persist-expanded-rows.md
@@ -2,6 +2,7 @@
 title: Persist Expanded Rows after Refresh
 page_title: Persist Expanded Rows after Refresh | Kendo UI Grid
 description: "Learn how to persist expanded rows after refresh in a Kendo UI Grid."
+previous_url: /controls/data-management/grid/how-to/persist-expanded-rows
 slug: howto_persist_expanded_rows_afetrrefresh_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/state/persist-grouped-grid-collapsed-details-state.md
+++ b/docs/controls/data-management/grid/how-to/state/persist-grouped-grid-collapsed-details-state.md
@@ -2,6 +2,7 @@
 title: Persist Collapsed State of Grouped Records
 page_title: Persist Collapsed State of Grouped Records | Kendo UI Grid
 description: "Learn how to persist the collapsed state of grouped records in a Kendo UI Grid."
+previous_url: /controls/data-management/grid/how-to/persist-grouped-grid-collapsed-details-state
 slug: howto_persist_collapsed_stateof_grouped_records_grid
 ---
 

--- a/docs/controls/data-management/grid/how-to/state/preserve-grid-state-in-a-cookie.md
+++ b/docs/controls/data-management/grid/how-to/state/preserve-grid-state-in-a-cookie.md
@@ -2,6 +2,7 @@
 title: Preserve Grid State in a Cookie
 page_title: Preserve Grid State in a Cookie | Kendo UI Grid
 description: "Learn how to preserve the Kendo UI Grid state in a cookie and restore it when the page is re-visited."
+previous_url: /controls/data-management/grid/how-to/preserve-grid-state-in-a-cookie
 slug: howto_preserve_gridstate_inacookie_grid
 ---
 
@@ -10,6 +11,7 @@ slug: howto_preserve_gridstate_inacookie_grid
 The example below demonstrates how to preserve the Grid state (filtering/sorting/paging/grouping and selection) in a cookie and restore it when the page is re-visited.
 
 > **Important**  
+>
 > If you are running the page directly from the hard-drive in Chrome, and not through a web server, Chrome will save no cookies for this page and persistence will not be available.
 
 ###### Example

--- a/docs/controls/data-management/grid/localization.md
+++ b/docs/controls/data-management/grid/localization.md
@@ -156,16 +156,13 @@ Find more information in the [`messages`](/api/javascript/ui/pager#messages-obje
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/localization.md
+++ b/docs/controls/data-management/grid/localization.md
@@ -8,7 +8,7 @@ position: 7
 
 # Grid Localization
 
-Localization is the process of adapting software to meet the requirements of local markets and different languages. Kendo widgets allow you to change the text messages that are displayed to the end user.
+Localization is the process of adapting software to meet the requirements of local markets and different languages. The Kendo UI widgets allow you to change the text messages that are displayed to the end user.
 
 The Grid widget provides a way to localize the user interface by using configuration options.
 

--- a/docs/controls/data-management/grid/overview.md
+++ b/docs/controls/data-management/grid/overview.md
@@ -20,21 +20,18 @@ Because of the numerous functionalities it supports, the Grid is the most comple
 * [DataSource]({% slug overview_kendoui_datasourcecomponent %})&mdash;The DataSource is one of the pivotal Kendo UI components. It is an abstraction for using local or remote data and a key concept in understanding how the Grid functions.
 * [Remote CRUD Operations]({% slug cruddataoperations_kendoui_datasourcecomponent %}#remote-transport-crud-operations)&mdash;The section elaborates on scenarios, in which data is retrieved from and submitted to a remote data service through HTTP requests made by the Kendo UI DataSource.
 * [Remote Data Binding]({% slug remote_data_binding_grid %})&mdash;The article provides information on server filtering, paging, and other features of the Grid.
-* [Grid Editing Functionality]({% slug editing_kendoui_grid_widget %})&mdash;The editing functionality of the Grid allows you to manipulate the way its data is presented.
 * [Kendo UI Editing Functionality]({% slug kendoui_editing_gettingstarted %})&mdash;The editing functionality in some Kendo UI widgets, including the Grid, is implemented with a specific editor element or form that is bound to the model by using the [Kendo UI MVVM bindings]({% slug overview_mvvmpattern_kendoui %}).
 
 ### Initialize the Grid
 
 Use either of the two primary approaches to create Kendo UI Grids:
 
-* From empty `<div>` elements.
-* From HTML tables.
+* From an empty `<div>` element.
+* From an HTML table.
 
-To initialize a scrollable Grid with a set height in a PanelBar, TabStrip, or Window, you need to consider some additional layout specifics of the widget. For more information on this scenario, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
+#### From an Empty div
 
-#### From Empty div Elements
-
-When you initialize the Grid from an empty `<div>` element, all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
+When you initialize the Grid from an empty `<div>` element, all Grid settings are provided in the initialization script statement. This means that you have to describe the layout and configuration of the Grid in JavaScript.
 
 ###### Example
 
@@ -69,9 +66,9 @@ When you initialize the Grid from an empty `<div>` element, all Grid settings ar
 
     </script>
 
-#### From HTML Tables
+#### From an HTML Table
 
-When you initialize the Grid from an HTML table, some settings of the Grid can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
+When you initialize the Grid from an HTML table, some of its settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
 
 The HTML table is usually already populated with data. This improves the accessibility and search engine optimization, and ensures that the user will see data even if JavaScript is disabled or there is a JavaScript error on the page.
 
@@ -116,7 +113,7 @@ The HTML table is usually already populated with data. This improves the accessi
 > **Important**  
 >
 > The Grid uses a Kendo UI DataSource instance even when the widget is created from an HTML table. The content of the cell is extracted and populates the DataSource in the following way:  
->    1. The names of the data fields in the DataSource are either created from the cell content of the header or from the `data-field` attributes of the header cells.  
+>    1. The names of the data fields in the DataSource are either created from the content of the header cells or from the `data-field` attributes of the header cells.  
 >    2. The names of the data fields have to be valid JavaScript identifiers. Therefore, it is recommended to use the `data-field` attributes. Otherwise the cell content of the header has to meet the following requirements:  
 >      * No spaces
 >      * No special characters
@@ -137,9 +134,9 @@ When the Grid is created from an existing table, you can define the following `c
 
 All attributes have to be applied to the `<th>` elements, except for the column width styles.
 
-It is not possible to define other column-related settings through HTML attributes in the `<table>`. If you have to use settings such as commands, locking, editors, custom rows, cell CSS classes, and others, skip the above attribute configuration and include all settings in the JavaScript initialization statement of the Grid. Note that you have to set the column properties through the `data-columns` attribute when using the declarative widget initialization.
+It is not possible to define other column-related settings through HTML attributes in the `<table>`. If you have to use settings, such as commands, locking, editors, custom rows, cell CSS classes, and others, skip the above attribute configuration and include all settings in the JavaScript initialization statement of the Grid. Note that you have to set the column properties through the `data-columns` attribute when using the declarative widget initialization.
 
-As the code snippets initiating the Grid above demonstrate, the client object of the Grid is attached to a `<div>` in the first case and to a `<table>` in the second case. However, the generated HTML output of the Grid entirely depends on the settings of the widget and it will always be the same, regardless of the way the widget is initialized.
+As the above code snippets demonstrate, the client object of the Grid is attached to a `<div>` in the first case and to a `<table>` in the second case. However, the generated HTML output of the Grid entirely depends on the settings of the widget and it will always be the same, regardless of the way the widget is initialized.
 
 ## Reference
 
@@ -152,27 +149,6 @@ The example below demonstrates how to access an existing Grid instance.
 ###### Example
 
     var grid = $("#grid").data("kendoGrid");
-
-## Keyboard Navigation
-
-Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
-
-The navigation occurs at a cell level regardless of what the `selectable` mode is. To select the current row or cell, press the space bar.
-
-The example below demonstrates how to enable the key navigation in the Grid.
-
-###### Example
-
-    $("#grid").kendoGrid({
-         navigatable: true
-         // other configuration
-    });
-
-The keyboard navigation of the Grid works by listening to the `keydown` events on the wrapper element of the widget. It is assumed that everything the user does is in accordance with the currently focused Grid cell, not the focused element of the browser.
-
-If the data cells of the Grid contain hyperlinks and you want to activate them through the keyboard, navigate to the respective Grid cell by using the `Arrow` keys, then press `Enter` to focus the hyperlink inside the cell, and press `Enter` again. To return the focus on the table cell, press `Esc`. In order for the hyperlinks to be inaccessible through tabbing, set the `tabindex="-1"` attribute to the custom hyperlinks.
-
-It is also possible to avoid the described procedure. The custom hyperlinks can be accessed through tabbing and activated through `Enter` by hacking and bypassing the keyboard navigation of the Grid. To achieve this, prevent the event bubbling of the `keydown` event of the custom hyperlinks. In this way, the `Enter` key-presses go unnoticed by the Grid.
 
 ## See Also
 

--- a/docs/controls/data-management/grid/overview.md
+++ b/docs/controls/data-management/grid/overview.md
@@ -32,7 +32,7 @@ Use either of the two primary approaches to create Kendo UI Grids:
 
 To initialize a scrollable Grid with a set height in a PanelBar, TabStrip, or Window, you need to consider some additional layout specifics of the widget. For more information on this scenario, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
 
-#### From Empty `<div>` Elements
+#### From Empty div Elements
 
 When you initialize the Grid from an empty `<div>` element, all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
 
@@ -141,235 +141,19 @@ It is not possible to define other column-related settings through HTML attribut
 
 As the code snippets initiating the Grid above demonstrate, the client object of the Grid is attached to a `<div>` in the first case and to a `<table>` in the second case. However, the generated HTML output of the Grid entirely depends on the settings of the widget and it will always be the same, regardless of the way the widget is initialized.
 
-## Configuration
+## Reference
 
-### Selection
+### Existing Instances
 
-To enable selection in the Grid, set the [`selectable`](/api/javascript/ui/grid#configuration-selectable) option to `true`. This enables the default single-row selection option.
+Refer to an existing Grid instance through the [`jQuery.data()`](http://api.jquery.com/jQuery.data/). Once a reference has been established, use the [Grid API](/api/javascript/ui/grid) to control its behavior.
 
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: true,
-            // other configuration
-         });
-
-**Figure 1. Grid with enabled row selection**
-
-![Grid with enabled row selection](/controls/data-management/grid/grid4_1.png)
-
-It is also possible to set the `selectable` option to any of the following values:
-* `row`
-* `cell`
-* `multiple row`
-* `multiple cell`
-
-#### The row Value
-
-The `row` value is set by default and enables a single row selection. It functions in the same way as the `selectable: true` configuration.
+The example below demonstrates how to access an existing Grid instance.
 
 ###### Example
 
-    $("#grid").kendoGrid({
-        selectable: "row",
-        // other configuration
-    });
+    var grid = $("#grid").data("kendoGrid");
 
-#### The cell Value
-
-The `cell` value enables the selection of individual cells within the Grid.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        selectable: "cell",
-        // other configuration
-    });
-
-#### The multiple row Value
-
-The `multiple row` value allows users to select multiple rows within the Grid.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        selectable: "multiple row",
-        // other configuration
-    });
-
-#### The multiple cell Value
-
-The `multiple cell` value enables the selection of multiple cells within the Grid.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        selectable: "multiple cell",
-        // other configuration
-    });
-
-When the multiple selection is enabled, it is possible to select multiple rows or cells by dragging the mouse cursor and select them in a similar way to a block of text.
-
-> **Important**  
-> * Selection is not persisted when the Grid is rebound, that is, when paging, filtering, sorting, editing, or virtual scrolling occurs. To achieve such behavior, [use this custom implementation]({% slug howto_persist_row_selection_paging_sorting_filtering_grid %}).
-> * Selection performance may decrease when the page size is too large, or if no paging is used, and the Grid is rendering hundreds or thousands of items. This behavior is most frequently seen in Internet Explorer. Grouping, hierarchy, and frozen columns also have a negative impact on the selection performance, because these features make the HTML output of the Grid more complex. Therefore, it is recommended to use paging and a reasonable page size.
-
-### Paging
-
-By default, paging is disabled.
-
-The paging functionality of the Grid is controlled by the `pageable` option. To configure it, use Boolean parameters.
-
-Additionally, you have to indicate to the Grid the number of records to display on each page as well as the total number of records in the dataset. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
-
-###### Example
-
-    $("#grid").kendoGrid({
-         pageable: true
-         // other configuration
-    });
-
-Try to do paging operations on the server to keep away from including too much data in the HTML, which might slow down page performance. To accomplish this, set the `serverPaging` option on the data source to `true`.
-
-If you decide to use server paging, be prepared to handle the requests to the server, and respond appropriately. When `serverPaging` is enabled, the data source will send the following default parameters to the server:
-
-* The `top` parameter defines the number of records to send back in the response.
-* The `skip` parameter defines the number of records to skip from the start of the dataset.
-
-For example, if you want to show page 3 out of a 60-record dataset split into 10 records per page, the Grid will send `skip: 20`, `top: 10`.
-
-In general, the Grid is platform-agnostic. This means that it works with HTTP requests sending and receiving JSON payload. For example, to bind the widget to a specific data subset (only to а particular page), instruct the dataSource to use [`serverPaging`](/api/javascript/data/datasource#configuration-serverPaging). In this way, it will directly use the received data. The same rule applies to the filtering, grouping, aggregation, and sorting operations.
-
-###### Example
-
-       $(document).ready(function(){
-          $("#grid").kendoGrid({
-             groupable: true,
-             scrollable: true,
-             sortable: true,
-             pageable: true
-          });
-      });
-
-### Grouping
-
-By default, grouping is disabled.
-
-To enable the grouping functionality of the Grid, set the `groupable` option to `true`. This exposes a new area in the header, which informs that it is possible for the user to drop a column on it and in this way to group the Grid data by that column. It is also possible to do grouping by multiple columns by dragging a second column onto the grouping header.
-
-###### Example
-
-    $("#grid").kendoGrid({
-         groupable: true
-         // other configuration
-    });
-
-**Figure 2. Grid with its grouping functionality enabled**
-
-![Grid With Grouping Enabled](/controls/data-management/grid/grid5_1.png)
-
-**Figure 3. Grid with its data grouped by last name**
-
-![Grid Grouped By Last Name](/controls/data-management/grid/grid6_1.png)
-
-It is also possible to sort the grouped content by clicking on the grouping tab. In the previous example, click on **lastName** to sort the grouped data in descending order. Click it again to toggle to ascending order. Each of the individual groups themselves can be toggled from expanded to collapsed states by clicking on the arrow next to the respective header grouping.
-
-Grouping can be configured to work also with:
-* Row templates
-* Paging
-
-#### Grouping with Row Templates
-
-By definition, a row template explicitly defines the row markup, while grouping requires changing the row markup. As a result, the two features can be used at the same time only if the row template includes a script which, depending on the number of existing groups, adds additional cells.
-
-###### Example
-
-    $(document).ready(function () {
-        // "window." can be omitted if the function is defined outside the document.ready closure
-        window.getGridGroupCells = function(id) {
-            var cnt = $("#" + id).data("kendoGrid").dataSource.group().length,
-                result = "";
-
-            for (var j = 0; j < cnt; j++) {
-                result += "<td class='k-group-cell'>&nbsp;</td>";
-            }
-
-            return result;
-        }
-
-        $("#GridID").kendoGrid({
-            groupable: true,
-            rowTemplate: "<tr>" +
-                "#= getGridGroupCells('GridID') #" +
-                "<td>...</td><td>...</td><td>...</td></tr>",
-            altRowTemplate: "<tr class='k-alt'>" +
-                "#= getGridGroupCells('GridID') #" +
-                "<td>...</td><td>...</td><td>...</td></tr>"
-        });
-    });
-
-#### Grouping with Paging
-
-Paging occurs before grouping. As a result, the following behavior is exhibited:
-
-* The dataSource instance of the Grid is not aware if there are items from the displayed groups on other pages.
-* If the groups are collapsed, it is not possible to display additional items and groups from other pages below the rendered items and groups. The only workaround is to increase the page size.
-
-To configure the Grid so that grouping occurs before paging, you need to group the whole dataSource. However, this setup is not recommended because it leads to a greatly reduced performance.
-
-### Sorting
-
-By default, sorting is disabled.
-
-**Figure 4. Grid with its sorting functionality enabled**
-
-![Grid with Sorting Enabled](/controls/data-management/grid/grid7_1.png)
-
-Sorting is also a function that can be pushed to the server for increased performance. This is done through the data source itself and by setting the `serverSorting` option on the data source to `true`. When you delegate the sorting to the server, you will receive the default `orderBy` parameter. This field will contain the field name of the column to sort by in the dataset.
-
-Sorting is supported in two formats:  
-* Single-column sorting
-* Multi-column sorting
-
-#### Single-Column Sorting
-
-To enable the single-column sorting, set the `sortable` option of the Grid to `true`. This enables the default single-column sorting.
-
-###### Example
-
-    $("#grid").kendoGrid({
-         sortable: true
-         // other configuration
-    });
-
-#### Multi-Column Sorting
-
-To enable the single-column sorting, set the `mode` option to `multiple`.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        sortable: {
-            mode: "multiple"
-        },
-        // other configuration
-    });
-
-### Scrolling
-
-By default, the scrolling functionality of the Grid is enabled. For historical reasons, however, the [Grid MVC wrapper]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) does not support it.
-
-For more information on scrolling, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#scrolling).
-
-### Virtual Scrolling
-
-When the Grid is bound to large datasets or when you apply large page sizes, it is important for the performance of the widget to reduce the active in-memory DOM objects.
-
-To highly optimize the binding to large sets of data, the Grid provides a built-in [UI virtualization functionality]({% slug virtualization_kendoui_combobox_widget %}).  Virtual scrolling is an alternative to paging. When enabled, the Grid loads data from the remote data source as the user scrolls vertically.
-
-For more information on virtual scrolling and its limitations, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
-
-### Keyboard Navigation
+## Keyboard Navigation
 
 Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
 
@@ -389,18 +173,6 @@ The keyboard navigation of the Grid works by listening to the `keydown` events o
 If the data cells of the Grid contain hyperlinks and you want to activate them through the keyboard, navigate to the respective Grid cell by using the `Arrow` keys, then press `Enter` to focus the hyperlink inside the cell, and press `Enter` again. To return the focus on the table cell, press `Esc`. In order for the hyperlinks to be inaccessible through tabbing, set the `tabindex="-1"` attribute to the custom hyperlinks.
 
 It is also possible to avoid the described procedure. The custom hyperlinks can be accessed through tabbing and activated through `Enter` by hacking and bypassing the keyboard navigation of the Grid. To achieve this, prevent the event bubbling of the `keydown` event of the custom hyperlinks. In this way, the `Enter` key-presses go unnoticed by the Grid.
-
-## Reference
-
-### Existing Instances
-
-Refer to an existing Grid instance through the [`jQuery.data()`](http://api.jquery.com/jQuery.data/). Once a reference has been established, use the [Grid API](/api/javascript/ui/grid) to control its behavior.
-
-The example below demonstrates how to access an existing Grid instance.
-
-###### Example
-
-    var grid = $("#grid").data("kendoGrid");
 
 ## See Also
 

--- a/docs/controls/data-management/grid/overview.md
+++ b/docs/controls/data-management/grid/overview.md
@@ -4,7 +4,7 @@ page_title: Overview | Kendo UI Grid
 description: "Learn how to create, initialize, and enable the Kendo UI Grid widget."
 previous_url: /web/grid/introduction
 slug: overview_kendoui_grid_widget
-position: 2
+position: 1
 ---
 
 # Grid Overview
@@ -29,6 +29,8 @@ Use either of the two primary approaches to create Kendo UI Grids:
 
 * From empty `<div>` elements.
 * From HTML tables.
+
+To initialize a scrollable Grid with a set height in a PanelBar, TabStrip, or Window, you need to consider some additional layout specifics of the widget. For more information on this scenario, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
 
 #### From Empty `<div>` Elements
 

--- a/docs/controls/data-management/grid/overview.md
+++ b/docs/controls/data-management/grid/overview.md
@@ -15,22 +15,24 @@ The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) is a po
 
 ### Read in Advance
 
-Because of the numerous functionalities it supports, the Grid is the most complex of the Kendo UI widgets so far. To gain greater confidence before you start working with it, make sure you get familiar with the concepts listed below in advance:
+Because of the numerous functionalities it supports, the Grid is the most complex of the Kendo UI widgets so far. To gain greater confidence before you start working with it, make sure you get familiar with the following concepts:
 
-* [DataSource]({% slug overview_kendoui_datasourcecomponent %})&mdash;The DataSource is one of the pivotal Kendo UI components. It is an abstraction for using local or remote data and is, therefore, a key concept in understanding how the Grid functions.
-* [Remote CRUD Operations]({% slug cruddataoperations_kendoui_datasourcecomponent %}#remote-transport-crud-operations)&mdash;The section elaborates on scenarios, in which data is retrieved from and submitted to a remote data service via HTTP requests made by the Kendo UI DataSource.
+* [DataSource]({% slug overview_kendoui_datasourcecomponent %})&mdash;The DataSource is one of the pivotal Kendo UI components. It is an abstraction for using local or remote data and a key concept in understanding how the Grid functions.
+* [Remote CRUD Operations]({% slug cruddataoperations_kendoui_datasourcecomponent %}#remote-transport-crud-operations)&mdash;The section elaborates on scenarios, in which data is retrieved from and submitted to a remote data service through HTTP requests made by the Kendo UI DataSource.
 * [Remote Data Binding]({% slug remote_data_binding_grid %})&mdash;The article provides information on server filtering, paging, and other features of the Grid.
-* [Grid Editing Functionality]({% slug editing_kendoui_grid_widget %})&mdash;The editing functionality of the Grid allows you to manipulate the way the data in it is presented.
-* [Kendo UI Editing Functionality]({% slug kendoui_editing_gettingstarted %})&mdash;The editing functionality in some Kendo UI widgets, including the Grid, is implemented with a specific editor element/form that is bound to the model using the [Kendo UI MVVM bindings]({% slug overview_mvvmpattern_kendoui %}).
+* [Grid Editing Functionality]({% slug editing_kendoui_grid_widget %})&mdash;The editing functionality of the Grid allows you to manipulate the way its data is presented.
+* [Kendo UI Editing Functionality]({% slug kendoui_editing_gettingstarted %})&mdash;The editing functionality in some Kendo UI widgets, including the Grid, is implemented with a specific editor element or form that is bound to the model by using the [Kendo UI MVVM bindings]({% slug overview_mvvmpattern_kendoui %}).
 
 ### Initialize the Grid
 
-There are two primary ways to create a Kendo UI Grid:
+Use either of the two primary approaches to create Kendo UI Grids:
 
-* From an empty `<div>` element. In this case all Grid settings are provided in the initialization script statement.
-* From an existing HTML `<table>` element. In this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements.
+* From empty `<div>` elements.
+* From HTML tables.
 
-#### From HTML Element: div
+#### From Empty `<div>` Elements
+
+When you initialize the Grid from an empty `<div>` element, all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
 
 ###### Example
 
@@ -65,9 +67,11 @@ There are two primary ways to create a Kendo UI Grid:
 
     </script>
 
-#### From HTML Table
+#### From HTML Tables
 
-When creating the Grid from a table, it is usually already populated with data. This improves the accessibility and search engine optimization, and ensures that the user will see data even if JavaScript is disabled or there is a JavaScript error on the page.
+When you initialize the Grid from an HTML table, some settings of the Grid can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
+
+The HTML table is usually already populated with data. This improves the accessibility and search engine optimization, and ensures that the user will see data even if JavaScript is disabled or there is a JavaScript error on the page.
 
 ###### Example
 
@@ -109,37 +113,130 @@ When creating the Grid from a table, it is usually already populated with data. 
 
 > **Important**  
 >
-> The Grid uses a Kendo UI DataSource instance even when the widget is created from a table. The cell content is extracted and populates the DataSource in this way:  
-> 1. The data field names in the DataSource are either created from the header cell content, or from the `data-field` attributes of the header cells.  
-> 2. The data field names must be valid JavaScript identifiers. Therefore, it is recommended to use `data-field` attributes. Otherwise the header cell content must comply with the following limitations:  
->   * No spaces
->   * No special characters
->   * The first character must be a letter
+> The Grid uses a Kendo UI DataSource instance even when the widget is created from an HTML table. The content of the cell is extracted and populates the DataSource in the following way:  
+>    1. The names of the data fields in the DataSource are either created from the cell content of the header or from the `data-field` attributes of the header cells.  
+>    2. The names of the data fields have to be valid JavaScript identifiers. Therefore, it is recommended to use the `data-field` attributes. Otherwise the cell content of the header has to meet the following requirements:  
+>      * No spaces
+>      * No special characters
+>      * The first character has to be a letter
 
-If the Grid is created from a `<table>`, but the DataSource is configured to use transport and remote operations, a remote request is made for the initial Grid state, even though the `<table>` may already be populated. This behavior is by design and cannot be avoided, except when using the Grid MVC wrapper.
+If the Grid is created from an HTML table, but the DataSource is configured to use transport and remote operations, a remote request is made for the initial Grid state even though the table might be already populated. This behavior is defined by design and cannot be avoided, except when using the MVC wrapper of the Grid.
 
-When creating the Grid from an existing table, you can define the following `column` settings via HTML attributes:
+When the Grid is created from an existing table, you can define the following `column` settings through the HTML attributes:
 
-* Define data field names via the `data-field` attributes.
-* Set column widths via the `width` styles applied to the respective `<col>` elements.
-* Define data types via the `data-type` attributes.
-* Set column templates via the `data-template` attributes.
-* Enable or disable the column menu via the `data-menu` attributes.
-* Enable or disable sorting via the `data-sortable` attributes.
-* Enable or disable filtering via the `data-filterable` attributes.
-* Enable or disable grouping via the `data-groupable` attributes.
+* The `data-field` attributes define the names of the data fields.
+* The `width` styles when applied to the respective `<col>` elements set the width of the columns.
+* The `data-type` attributes define the data types.
+* The `data-template` attributes set the column templates.
+* The `data-menu` attributes enable or disable the column menu.
+* The `data-sortable` attributes enable or disable sorting.
+* The `data-filterable` attributes enable or disable filtering.
+* The `data-groupable` attributes enable or disable grouping.
 
-All attributes must be applied to the `<th>` elements, except for the column width styles.
+All attributes have to be applied to the `<th>` elements, except for the column width styles.
 
-Other column-related settings cannot be defined via HTML attributes in the `<table>`. If you must use such settings, e.g. commands, locking, editors, custom row, or cell CSS classes, etc., the above attribute configuration should be abandoned and all settings should be included in the Grid's JavaScript initialization statement. Note that when using a declarative widget initialization, you must set the column properties via the `data-columns` attribute.
+It is not possible to define other column-related settings through HTML attributes in the `<table>`. If you have to use settings such as commands, locking, editors, custom rows, cell CSS classes, and others, skip the above attribute configuration and include all settings in the JavaScript initialization statement of the Grid. Note that you have to set the column properties through the `data-columns` attribute when using the declarative widget initialization.
 
-As seen from the code snippets above, in the first case the Grid client object is attached to a `<div>`, while in the second one the object is attached to a `<table>`. However, the generated HTML output of the Grid depends entirely on the widget settings and it will always be the same, no matter how the widget is initialized.
+As the code snippets initiating the Grid above demonstrate, the client object of the Grid is attached to a `<div>` in the first case and to a `<table>` in the second case. However, the generated HTML output of the Grid entirely depends on the settings of the widget and it will always be the same, regardless of the way the widget is initialized.
 
 ## Configuration
 
-### Paging, Sorting, Grouping, and Scrolling
+### Selection
 
-To configure the paging, sorting, grouping, or scrolling functionality of the Grid, use simple Boolean configuration options. Note that, by default, paging, grouping, and sorting are disabled, and scrolling is enabled.
+To enable selection in the Grid, set the [`selectable`](/api/javascript/ui/grid#configuration-selectable) option to `true`. This enables the default single-row selection option.
+
+###### Example
+
+        $("#grid").kendoGrid({
+            selectable: true,
+            // other configuration
+         });
+
+**Figure 1. Grid with enabled row selection**
+
+![Grid with enabled row selection](/controls/data-management/grid/grid4_1.png)
+
+It is also possible to set the `selectable` option to any of the following values:
+* `row`
+* `cell`
+* `multiple row`
+* `multiple cell`
+
+#### The row Value
+
+The `row` value is set by default and enables a single row selection. It functions in the same way as the `selectable: true` configuration.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "row",
+        // other configuration
+    });
+
+#### The cell Value
+
+The `cell` value enables the selection of individual cells within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "cell",
+        // other configuration
+    });
+
+#### The multiple row Value
+
+The `multiple row` value allows users to select multiple rows within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "multiple row",
+        // other configuration
+    });
+
+#### The multiple cell Value
+
+The `multiple cell` value enables the selection of multiple cells within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "multiple cell",
+        // other configuration
+    });
+
+When the multiple selection is enabled, it is possible to select multiple rows or cells by dragging the mouse cursor and select them in a similar way to a block of text.
+
+> **Important**  
+> * Selection is not persisted when the Grid is rebound, that is, when paging, filtering, sorting, editing, or virtual scrolling occurs. To achieve such behavior, [use this custom implementation]({% slug howto_persist_row_selection_paging_sorting_filtering_grid %}).
+> * Selection performance may decrease when the page size is too large, or if no paging is used, and the Grid is rendering hundreds or thousands of items. This behavior is most frequently seen in Internet Explorer. Grouping, hierarchy, and frozen columns also have a negative impact on the selection performance, because these features make the HTML output of the Grid more complex. Therefore, it is recommended to use paging and a reasonable page size.
+
+### Paging
+
+By default, paging is disabled.
+
+The paging functionality of the Grid is controlled by the `pageable` option. To configure it, use Boolean parameters.
+
+Additionally, you have to indicate to the Grid the number of records to display on each page as well as the total number of records in the dataset. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
+
+###### Example
+
+    $("#grid").kendoGrid({
+         pageable: true
+         // other configuration
+    });
+
+Try to do paging operations on the server to keep away from including too much data in the HTML, which might slow down page performance. To accomplish this, set the `serverPaging` option on the data source to `true`.
+
+If you decide to use server paging, be prepared to handle the requests to the server, and respond appropriately. When `serverPaging` is enabled, the data source will send the following default parameters to the server:
+
+* The `top` parameter defines the number of records to send back in the response.
+* The `skip` parameter defines the number of records to skip from the start of the dataset.
+
+For example, if you want to show page 3 out of a 60-record dataset split into 10 records per page, the Grid will send `skip: 20`, `top: 10`.
+
+In general, the Grid is platform-agnostic. This means that it works with HTTP requests sending and receiving JSON payload. For example, to bind the widget to a specific data subset (only to а particular page), instruct the dataSource to use [`serverPaging`](/api/javascript/data/datasource#configuration-serverPaging). In this way, it will directly use the received data. The same rule applies to the filtering, grouping, aggregation, and sorting operations.
 
 ###### Example
 
@@ -152,31 +249,152 @@ To configure the paging, sorting, grouping, or scrolling functionality of the Gr
           });
       });
 
-### Virtualization
+### Grouping
 
-When binding to large data sets or when using large page sizes, reducing active in-memory DOM objects is important for the performance of the widget. The Grid provides a built-in [UI virtualization functionality]({% slug virtualization_kendoui_combobox_widget %}) for highly optimized binding to large sets of data. Enabling virtual scrolling is done by means of a simple configuration.
+By default, grouping is disabled.
+
+To enable the grouping functionality of the Grid, set the `groupable` option to `true`. This exposes a new area in the header, which informs that it is possible for the user to drop a column on it and in this way to group the Grid data by that column. It is also possible to do grouping by multiple columns by dragging a second column onto the grouping header.
 
 ###### Example
 
-       $(document).ready(function(){
-          $("#grid").kendoGrid({
-             scrollable: {
-                 virtual: true
-             }
-          });
-      });
+    $("#grid").kendoGrid({
+         groupable: true
+         // other configuration
+    });
 
-For more information on the layout features avaialbe in the Grid, refer to:
+**Figure 2. Grid with its grouping functionality enabled**
 
-* [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
+![Grid With Grouping Enabled](/controls/data-management/grid/grid5_1.png)
+
+**Figure 3. Grid with its data grouped by last name**
+
+![Grid Grouped By Last Name](/controls/data-management/grid/grid6_1.png)
+
+It is also possible to sort the grouped content by clicking on the grouping tab. In the previous example, click on **lastName** to sort the grouped data in descending order. Click it again to toggle to ascending order. Each of the individual groups themselves can be toggled from expanded to collapsed states by clicking on the arrow next to the respective header grouping.
+
+Grouping can be configured to work also with:
+* Row templates
+* Paging
+
+#### Grouping with Row Templates
+
+By definition, a row template explicitly defines the row markup, while grouping requires changing the row markup. As a result, the two features can be used at the same time only if the row template includes a script which, depending on the number of existing groups, adds additional cells.
+
+###### Example
+
+    $(document).ready(function () {
+        // "window." can be omitted if the function is defined outside the document.ready closure
+        window.getGridGroupCells = function(id) {
+            var cnt = $("#" + id).data("kendoGrid").dataSource.group().length,
+                result = "";
+
+            for (var j = 0; j < cnt; j++) {
+                result += "<td class='k-group-cell'>&nbsp;</td>";
+            }
+
+            return result;
+        }
+
+        $("#GridID").kendoGrid({
+            groupable: true,
+            rowTemplate: "<tr>" +
+                "#= getGridGroupCells('GridID') #" +
+                "<td>...</td><td>...</td><td>...</td></tr>",
+            altRowTemplate: "<tr class='k-alt'>" +
+                "#= getGridGroupCells('GridID') #" +
+                "<td>...</td><td>...</td><td>...</td></tr>"
+        });
+    });
+
+#### Grouping with Paging
+
+Paging occurs before grouping. As a result, the following behavior is exhibited:
+
+* The dataSource instance of the Grid is not aware if there are items from the displayed groups on other pages.
+* If the groups are collapsed, it is not possible to display additional items and groups from other pages below the rendered items and groups. The only workaround is to increase the page size.
+
+To configure the Grid so that grouping occurs before paging, you need to group the whole dataSource. However, this setup is not recommended because it leads to a greatly reduced performance.
+
+### Sorting
+
+By default, sorting is disabled.
+
+**Figure 4. Grid with its sorting functionality enabled**
+
+![Grid with Sorting Enabled](/controls/data-management/grid/grid7_1.png)
+
+Sorting is also a function that can be pushed to the server for increased performance. This is done through the data source itself and by setting the `serverSorting` option on the data source to `true`. When you delegate the sorting to the server, you will receive the default `orderBy` parameter. This field will contain the field name of the column to sort by in the dataset.
+
+Sorting is supported in two formats:  
+* Single-column sorting
+* Multi-column sorting
+
+#### Single-Column Sorting
+
+To enable the single-column sorting, set the `sortable` option of the Grid to `true`. This enables the default single-column sorting.
+
+###### Example
+
+    $("#grid").kendoGrid({
+         sortable: true
+         // other configuration
+    });
+
+#### Multi-Column Sorting
+
+To enable the single-column sorting, set the `mode` option to `multiple`.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        sortable: {
+            mode: "multiple"
+        },
+        // other configuration
+    });
+
+### Scrolling
+
+By default, the scrolling functionality of the Grid is enabled. For historical reasons, however, the [Grid MVC wrapper]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) does not support it.
+
+For more information on scrolling, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#scrolling).
+
+### Virtual Scrolling
+
+When the Grid is bound to large datasets or when you apply large page sizes, it is important for the performance of the widget to reduce the active in-memory DOM objects.
+
+To highly optimize the binding to large sets of data, the Grid provides a built-in [UI virtualization functionality]({% slug virtualization_kendoui_combobox_widget %}).  Virtual scrolling is an alternative to paging. When enabled, the Grid loads data from the remote data source as the user scrolls vertically.
+
+For more information on virtual scrolling and its limitations, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
+
+### Keyboard Navigation
+
+Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
+
+The navigation occurs at a cell level regardless of what the `selectable` mode is. To select the current row or cell, press the space bar.
+
+The example below demonstrates how to enable the key navigation in the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+         navigatable: true
+         // other configuration
+    });
+
+The keyboard navigation of the Grid works by listening to the `keydown` events on the wrapper element of the widget. It is assumed that everything the user does is in accordance with the currently focused Grid cell, not the focused element of the browser.
+
+If the data cells of the Grid contain hyperlinks and you want to activate them through the keyboard, navigate to the respective Grid cell by using the `Arrow` keys, then press `Enter` to focus the hyperlink inside the cell, and press `Enter` again. To return the focus on the table cell, press `Esc`. In order for the hyperlinks to be inaccessible through tabbing, set the `tabindex="-1"` attribute to the custom hyperlinks.
+
+It is also possible to avoid the described procedure. The custom hyperlinks can be accessed through tabbing and activated through `Enter` by hacking and bypassing the keyboard navigation of the Grid. To achieve this, prevent the event bubbling of the `keydown` event of the custom hyperlinks. In this way, the `Enter` key-presses go unnoticed by the Grid.
 
 ## Reference
 
 ### Existing Instances
 
-Refer to an existing Grid instance via the [`jQuery.data()`](http://api.jquery.com/jQuery.data/). Once a reference has been established, use the [Grid API](/api/javascript/ui/grid) to control its behavior.
+Refer to an existing Grid instance through the [`jQuery.data()`](http://api.jquery.com/jQuery.data/). Once a reference has been established, use the [Grid API](/api/javascript/ui/grid) to control its behavior.
 
-The example below demonstrates how to access and existing Grid instance.
+The example below demonstrates how to access an existing Grid instance.
 
 ###### Example
 
@@ -184,18 +402,17 @@ The example below demonstrates how to access and existing Grid instance.
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Overview of the ASP.NET MVC HtmlHelper Extension for the Grid Widget](/aspnet-mvc/helpers/grid/overview)
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
+* [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Overview of the ASP.NET MVC HtmlHelper Extension for the Grid Widget]({% slug overview_gridhelper_aspnetmvc %})
 * [Overview of the Grid JSP Tag]({% slug overview_grid_uiforjsp %})
-* [Overview of the Grid PHP Class](/php/widgets/grid/overview)
+* [Overview of the Grid PHP Class]({% slug overview_grid_uiforphp %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/pdf-export.md
+++ b/docs/controls/data-management/grid/pdf-export.md
@@ -8,7 +8,7 @@ position: 9
 
 # PDF Export
 
-As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014) the Grid widget provides a built-in PDF export functionality.
+As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid widget provides a built-in PDF export functionality.
 
 ## Set Up
 
@@ -388,16 +388,13 @@ Note that even with the proper CORS headers, IE9 will not be able to load images
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Printing of the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/pdf-export.md
+++ b/docs/controls/data-management/grid/pdf-export.md
@@ -10,7 +10,7 @@ position: 9
 
 As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid widget provides a built-in PDF export functionality.
 
-## Set Up
+## Setup
 
 To enable PDF export, include the corresponding toolbar command and configure the export settings.
 
@@ -150,20 +150,20 @@ The example below demonstrates how to export the Grid with a fixed paper size.
 
 ### Page Template
 
-Starting from the 2016.2 release, the Grid allows you to specify a page template.
-The template can be used to position the content, add headers, footers and other elements.
-Styling is done using CSS. The template will be positioned in a container with the specified
-paper size during export.
+As of the Kendo UI 2016.2 release, the Grid allows you to specify a page template. It is possible to use the template to position the content, add headers, footers, and other elements. The styling of the exported document is done by using CSS. During the PDF export, the template is positioned in a container with the specified paper size.
 
-Available template variables include:
-* pageNumber
-* totalPages
+The following page template variables are available:
+* `pageNumber`
+* `totalPages`
 
 > **Important**
 >
-> Using a template requires setting paper size. See above.
+> It is required to set the paper size when you use a page template. For more information, refer to the section on [page templates](#page-templates).
 
-###### Example - Export With Page Template
+The example below demonstrates how to export a Grid by using a page template.
+
+###### Example
+
 ```html
     <style>
         body {

--- a/docs/controls/data-management/grid/print-export.md
+++ b/docs/controls/data-management/grid/print-export.md
@@ -8,25 +8,124 @@ position: 10
 
 # Printing
 
-In most cases the Grid is not the only content on a page and, yet, you might want to print the Grid only.
+In most cases, the Grid is not the only content on a page. Yet, you might want to print the Grid only.
+
+## Overview
+
+If scrolling is enabled (which is set by default except for the MVC wrapper of the Grid), the Grid renders a [separate table for the header area](#scrolling). Because the browser is not able to understand the relationship between the two Grid tables, it will not repeat the header row on top of every printed page.
+
+The following example addresses this issue by cloning the header row and prepending it to the printable Grid. Alternatively, it is possible to [disable the scrolling functionality of the Grid]({% slug appearance_kendoui_grid_widget %}#scrolling).
+
+###### Example
+
+    //HTML
+    <div id="grid"></div>
+
+    <script type="text/x-kendo-template" id="toolbar-template">
+        <button type="button" class="k-button" id="printGrid">Print Grid</button>
+    </script>
+
+    //JavaScript
+	function printGrid() {
+		var gridElement = $('#grid'),
+			printableContent = '',
+			win = window.open('', '', 'width=800, height=500'),
+			doc = win.document.open();
+
+		var htmlStart =
+				'<!DOCTYPE html>' +
+				'<html>' +
+				'<head>' +
+				'<meta charset="utf-8" />' +
+				'<title>Kendo UI Grid</title>' +
+				'<link href="http://kendo.cdn.telerik.com/' + kendo.version + '/styles/kendo.common.min.css" rel="stylesheet" /> ' +
+				'<style>' +
+				'html { font: 11pt sans-serif; }' +
+				'.k-grid { border-top-width: 0; }' +
+				'.k-grid, .k-grid-content { height: auto !important; }' +
+				'.k-grid-content { overflow: visible !important; }' +
+				'.k-grid .k-grid-header th { border-top: 1px solid; }' +
+				'.k-grid-toolbar, .k-grid-pager > .k-link { display: none; }' +
+				'</style>' +
+				'</head>' +
+				'<body>';
+
+		var htmlEnd =
+				'</body>' +
+				'</html>';
+
+		var gridHeader = gridElement.children('.k-grid-header');
+		if (gridHeader[0]) {
+			var thead = gridHeader.find('thead').clone().addClass('k-grid-header');
+			printableContent = gridElement
+				.clone()
+					.children('.k-grid-header').remove()
+				.end()
+					.children('.k-grid-content')
+						.find('table')
+							.first()
+								.children('tbody').before(thead)
+							.end()
+						.end()
+					.end()
+				.end()[0].outerHTML;
+		} else {
+			printableContent = gridElement.clone()[0].outerHTML;
+		}
+
+		doc.write(htmlStart + printableContent + htmlEnd);
+		doc.close();
+		win.print();
+	}
+
+	$(document).ready(function () {
+		var grid = $('#grid').kendoGrid({
+			dataSource: {
+				type: 'odata',
+				transport: {
+					read: "http://demos.telerik.com/kendo-ui/service/Northwind.svc/Products"
+				},
+				pageSize: 20,
+				serverPaging: true,
+				serverSorting: true,
+				serverFiltering: true
+			},
+			toolbar: kendo.template($('#toolbar-template').html()),
+			height: 400,
+			pageable: true,
+			columns: [
+				{ field: 'ProductID', title: 'Product ID', width: 100 },
+				{ field: 'ProductName', title: 'Product Name' },
+				{ field: 'UnitPrice', title: 'Unit Price', width: 100 },
+				{ field: 'QuantityPerUnit', title: 'Quantity Per Unit' }
+			]
+		});
+
+		$('#printGrid').click(function () {
+			printGrid();
+		});
+
+	});
 
 ## Options
 
-There are two ways to print the content of the Grid only, though the Grid itself may not be the only content displayed on a page.
+To print the content of the Grid only though the widget might not be the only content on the page, use either of the options:
+* Print existing web pages
+* Print new web pages
 
 ### Print Existing Web Pages
 
-Print the existing web page, but use a print stylesheet to hide the parts of the page that are not needed.
+To print the Grid only from existing web pages, print the existing web page, but use a print stylesheet to hide the parts of the page that you do not need.
 
 ### Print New Web Pages
 
-The example below demonstrates how to retrieve the Grid HTML, inject it in a new browser window, and trigger the printing of the new page. It also addresses some other important things you must keep in mind as follows:
+The following example demonstrates how to retrieve the HTML of the Grid, inject it in a new browser window, and trigger the printing of the new page. This approach also addresses some other important things you need to consider:
 
 * If the Grid is scrollable, some rows or columns may not be visible on the printed paper. Make sure that during printing the Grid has no set height, and the scrollability of the data area is disabled.
 * Depending on the column width, some of the cell content may not be fully visible. This problem is resolved by forcing an automatic `table-layout` to the Grid table, which disables the ellipsis (`...`).
-* Browsers repeat table headers on each printed page automatically. However, when the Grid is scrollable, it renders a separate table for the header area. Since the browser cannot understand the relationship between the two Grid tables, it will not repeat the header row. This problem is resolved by cloning the header row inside the data table.
+* If scrolling is enabled (which is set by default except for the MVC wrapper of the Grid), the Grid renders a separate table for the header area. For more information on this issue, refer to the [previous section](#overview).
 
-Printing a Grid with locked (frozen) columns is likely to produce misaligned columns, or rows, or a broken overall layout. In such cases it is advisable to use a separate print-friendly page with no frozen columns.
+When printing a Grid with locked (frozen) columns, it is possible that the resulting columns or rows are misaligned, or the overall layout is broken. In such cases, it is advisable to use a separate print-friendly page with no frozen columns.
 
 ###### Example
 
@@ -123,16 +222,14 @@ Printing a Grid with locked (frozen) columns is likely to produce misaligned col
 
 ## See Also
 
-Other articles on the Kendo UI Grid:
-
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Walkthrough of the Grid]({% slug walkthrough_kendoui_grid_widget %})
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
+* [Editing Functionality of the Grid]({% slug editing_kendoui_grid_widget %})
+* [Remote Data Binding of the Grid]({% slug remote_data_binding_grid %})
 * [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Remote Data Binding]({% slug remote_data_binding_grid %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Localization of Messages in the Grid]({% slug localization_kendoui_grid_widget %})
+* [Adaptive Rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Export of the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export of the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -17,7 +17,7 @@ Use either of the two primary approaches to create Kendo UI Grids:
 * From empty `<div>` elements&mdash;in this case all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
 * From HTML tables&mdash;in this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
 
-### From Empty `<div>` Elements
+### From Empty div Elements
 
 1. Start with an empty `<div>` element that has an ID.
 
@@ -90,7 +90,7 @@ Use either of the two primary approaches to create Kendo UI Grids:
 
     When you create the Grid from an existing HTML table, each row from the table is added as a data item to the dataSource of the Grid. As a result, your Grid is populated with the content from the table and reflects the information it contains.
 
-For more information on initializing the Grid, refer to [its introductory article]({% slug overview_kendoui_grid_widget %}).
+For more information on initializing the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}).
 
 ## Data Binding
 
@@ -153,7 +153,7 @@ If multiple widgets are bound to the same data set, you have to create the data 
          }
     });
 
-For more information on this topic, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}).
+For more information on binding the Grid to a remote data source, refer to the article on [remote data binding of the widget]({% slug remote_data_binding_grid %}).
 
 ## Height
 
@@ -165,13 +165,13 @@ When the height of the Grid is set, it calculates the appropriate height of its 
 
 ![Grid with fixed height and scrolling](/controls/data-management/grid/grid3_1.png)
 
-For more information on setting the height, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#height).
+For more information on setting the height of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#height).
 
 ### Let the Height Vary within Limits
 
 It is possible to make the Grid expand and shrink vertically according to the number of its rows and yet within certain limits. To achieve this, apply a minimum and/or maximum height style to the scrollable data area and do not set any height of the Grid.
 
-For more information on setting the height vary within limits, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#let-the-height-vary-within-limits).
+For more information on setting the height vary within limits in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#let-the-height-vary-within-limits).
 
 ### Set a 100% Height and Auto-Resize
 
@@ -185,7 +185,7 @@ If the vertical space that is available for the Grid depends on a custom resizin
 
 The `resize` method works for the Kendo UI versions delivered after the Kendo UI Q3 2013 release.
 
-For more information on setting the height to 100% and auto-resize the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#set-100-height-and-auto-resize).
+For more information on setting the height to 100% and auto-resize the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#set-100-height-and-auto-resize).
 
 ### Configure the Loading Indicator
 
@@ -193,7 +193,7 @@ Internally, the Grid uses the [`kendo.ui.progress`](/api/javascript/ui/ui#method
 
 If the scrolling functionality of the Grid is disabled, the overlay is displayed over the whole Grid. If scrolling is enabled, the overlay is displayed over the scrollable data area.
 
-For more information on initializing the Grid inside hidden containers, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#configure-the-loading-indicator).
+For more information on configuring the loading indicator in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#configure-the-loading-indicator).
 
 ## Width
 
@@ -205,7 +205,7 @@ If you enable the scrolling functionality of the Grid and the sum of all column 
 
 If you disable the scrolling functionality of the Grid and the columns do not fit, they overflow the `<div>` element of the Grid.
 
-For more information on configuring the width of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#width).
+For more information on configuring the width of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#width).
 
 ## Columns
 
@@ -217,13 +217,13 @@ By default, scrolling is enabled&mdash;except for the MVC wrapper of the Grid&md
 
 When scrolling is disabled, the `table-layout` style is set to `auto`, which is the default behavior of HTML tables. This means that if not explicitly set, the column widths are determined by the browser and by the cell content.
 
-For more information on configuring the column widths of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#column-widths).
+For more information on configuring the column widths of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#column-widths).
 
 ### Column Resizing
 
 When scrolling is disabled and a column is resized, other columns change widths too, so that the sum of all column widths remains constant. If both the columns and the Grid `<div>` already have their minimum possible widths applied, then the resizing of the columns stops working. In such scenarios, either apply a larger width to the Grid, or enable scrolling.
 
-For more information on resizing the columns of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#column-resizing).
+For more information on resizing the columns of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#column-resizing).
 
 ### Locked Columns
 
@@ -241,9 +241,9 @@ These settings ensure that at least one non-locked column is always visible and 
 
 The row template and detail features are not supported in combination with column locking. It is possible to lock a column at the topmost level only, if you use [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders).
 
-Frozen columns cannot be touch-scrolled, because they are wrapped in a container with an `overflow:hidden` style.
+It is not possible to scroll frozen columns by touch, because they are wrapped in a container with an `overflow:hidden` style.
 
-For more information on locking columns, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#locked-columns).
+For more information on locking columns in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#locked-columns).
 
 ### Column Templates
 
@@ -251,19 +251,21 @@ Columns need additional specific templating when they represent complex displays
 
 For more information on configuring columns by using templates in the Grid, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}#set-the-column-template).
 
+For more information on the templating features in Kendo UI, refer to the [introductory article on templates]({% slug overview_kendoui_templatescomponent %}).
+
 ## Rows
 
-### Rows by Model IDs
+### Model IDs
 
-It is possible to get a table row in the Grid by the data item ID.
+It is possible to get a table row in the Grid by the ID of the data item.
 
-For more information on how to retrieve rows by a model ID, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#rows-by-model-ids).
+For more information on how to retrieve rows by a model ID in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#rows-by-model-ids).
 
 ### Custom Rows When No Records Are Loaded
 
 It is possible to manually add a table row with some user-friendly message when the dataSource does not return any data&mdash;for example, as a result of filtering.
 
-For more information on adding custom rows when no records are loaded, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#custom-rows-when-no-records-are-loaded).
+For more information on adding custom rows when no records are loaded in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#custom-rows-when-no-records-are-loaded).
 
 ### Row Templates  
 
@@ -273,7 +275,9 @@ It is possible to format any cell in the Grid by using templates within a script
 
 ![Grid With Row Template](/controls/data-management/grid/grid8_1.png)
 
-For more information on using row templates, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#row-templates).
+For more information on using row templates in the Grid, refer to the article on its [appearance]({% slug appearance_kendoui_grid_widget %}#row-templates).
+
+For more information on the templating features in Kendo UI, refer to the [introductory article on templates]({% slug overview_kendoui_templatescomponent %}).
 
 ## Features
 
@@ -291,7 +295,7 @@ It is also possible to set the `selectable` option to any of the following value
 * `multiple row`
 * `multiple cell`
 
-For more information on the selection functionality and its limitations, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Selection).
+For more information on the selection functionality and its limitations in the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Selection).
 
 ### Paging
 
@@ -306,7 +310,7 @@ The paging function of the Grid is controlled by the `pageable` option. Addition
          // other configuration
     });
 
-For more information on paging, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Paging).
+For more information on the paging functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Paging).
 
 ### Grouping
 
@@ -333,7 +337,7 @@ It is also possible to sort the grouped content by clicking on the grouping tab.
 
 Grouping can be configured to work also with row templates and together with paging.
 
-For more information on the grouping functionality, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Grouping).
+For more information on the grouping functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Grouping).
 
 ### Sorting
 
@@ -349,7 +353,22 @@ Sorting is supported in two formats:
 * Single-column sorting
 * Multi-column sorting
 
-For more information on the sorting functionality, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Sorting).
+For more information on the sorting functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Sorting).
+
+### Editing
+
+Editing is one of the basic functionalities Kendo UI Grid supports and it allows you to manipulate the way the data is presented.
+
+To set up the editing functionality of the Grid:
+* Configure the dataSource of the widget.
+* Declare the definitions of the fields through the `schema` option of the dataSource.
+* Set the `editable` configuration option.
+
+When editing the Grid, it is possible to work with:
+* Foreign key columns
+* Custom editors
+
+For more information on the editing functionality of the Grid, refer to the article on [editing of the widget]({% slug editing_kendoui_grid_widget %}).
 
 ### Scrolling
 
@@ -369,9 +388,9 @@ Though the scrolling functionality is enabled, the scrollbars do not necessarily
 1. To achieve vertical scrolling, set the height of the Grid. Otherwise, it will expand vertically to show all rows.
 1. To achieve horizontal scrolling, explicitly define the width of all columns in pixels and make sure their sum exceeds the width of the Grid.
 
-You can control vertical and horizontal scrolling independently.
+It is possible for you to control vertical and horizontal scrolling independently.
 
-For more information on the scrolling functionality, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#scrolling).
+For more information on the scrolling functionality of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#scrolling).
 
 #### Remove Vertical Scrollbar
 
@@ -403,7 +422,7 @@ To enable virtual scrolling, use the configuration demonstrated in the following
           });
       });
 
-For more information on virtual scrolling and its limitations, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
+For more information on the virtual scrolling and its limitations in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
 
 ### Keyboard Navigation
 
@@ -420,55 +439,81 @@ The example below demonstrates how to enable the key navigation in the Grid.
          // other configuration
     });
 
-For more information on the keyboard navigation, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Keyboard).
+For more information on the keyboard navigation of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Keyboard).
 
 ## Hidden Containers
 
 If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
 
-For more information on initializing the Grid inside hidden containers, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
+When you handle the initialization of the Grid in hidden containers, it is possible to use some general as well as specific approaches depending on the particular scenario.
 
-## Editing
-
-Editing is one of the basic functionalities Kendo UI Grid supports and it allows you to manipulate the way the data is presented.
-
-For more information on the editing functionality, refer to the article on [editing of the Grid]({% slug editing_kendoui_grid_widget %}).
+For more information on initializing the Grid inside hidden containers and the approaches to consider, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
 
 ## Adaptive Rendering
 
-As of the Kendo UI Q3 2013 release, the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
+As of the [Kendo UI Q3 2013 release](http://www.telerik.com/blogs/new-in-kendo-ui-q3-2013), the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
 
-For more information on the responsive web design, refer to the article on the [adaptive rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %}).
+To enable the adaptive rendering feature of the Grid, set the [`mobile`](/api/javascript/ui/grid#configuration-mobile) property to `true`, `phone`, or `tablet`.
+
+When configuring the Grid in terms of responsive web design, it is possible to:
+* Add an adaptive Grid to a Kendo UI mobile application
+* Apply height and positions to parent Grid elements
+* Destroy and adaptive Grid
+
+For more information on the responsive web design of the Grid, refer to the article on the [adaptive rendering of the widget]({% slug adaptive_rendering_kendoui_grid_widget %}).
 
 ## Localization
 
-Localization is the process of adapting software to meet the requirements of local markets and different languages. Kendo widgets allow you to change the text messages that are displayed to the end user.
+The Kendo UI widgets allow you to change the text messages that are displayed to the end user.
 
-The Grid widget provides a way to localize the user interface by using configuration options.
+The Grid provides options to localize messages related to the toolbar, columns, filter, grouping, and paging, by setting the following configurations:  
+* `toolbar`
+* `columnMenu`
+* `columns`
+* `filterable`
+* `groupable`
+* `pageable`
 
-For more information on localization, refer to the article on [localizing the Grid]({% slug localization_kendoui_grid_widget %}).
+For more information on localizing messages in the Grid, refer to the article on [localizing the widget]({% slug localization_kendoui_grid_widget %}).
 
 ## Export to Excel
 
 As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in Excel export functionality.
 
-For more information on Excel export and its limitations, refer to the article on [exporting the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %}).
+The Excel export of the Grid provides the following options and support:
+* Export of all data
+* Customization of the generated Excel document
+* Reversion of the cells and Right-to-Left (RTL) support
+* Row types
+* Export of multiple Grids
+* Saving files on the server
+* Export of huge data sets to Excel
+
+For more information on the Excel export of the Grid and its limitations, refer to the article on [exporting of the widget to Excel]({% slug exporting_excel_kendoui_grid_widget %}).
 
 ## Export to PDF
 
 As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in PDF export functionality.
 
-For more information on PDF export and its limitations, refer to the article on [exporting the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %}).
+The PDF export of the Grid provides the following options and support:  
+* Export of all pages
+* Fit the Grid to the paper size
+* Use page templates
+* Save files by using a server proxy
+* Save files on the server
+* Embed custom fonts and provide Unicode support
+
+For more information on the PDF export of the Grid and its limitations, refer to the article on [exporting of the widget in PDF]({% slug exporting_pdf_kendoui_grid_widget %}).
 
 ## Printing
 
 In most cases, the Grid is not the only content on a page. Yet, you might want to print the Grid only.
 
-To print the content of the Grid only though the widget might not be the only content on the page, use either of the options:
+To print the content of the Grid only, though the widget might not be the only content on the page, it is possible to use either of the options:
 * Print existing web pages
 * Print new web pages
 
-For more information on printing, refer to the article on [printing the Grid]({% slug printing_kendoui_grid %}).
+For more information on printing the Grid, refer to the article on [printing the widget]({% slug printing_kendoui_grid %}).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -3,103 +3,12 @@ title: Walkthrough
 page_title: Walkthrough | Kendo UI Grid
 description: "Learn how to create a grid, add an HTML table and control the features of the Kendo UI Grid widget."
 slug: walkthrough_kendoui_grid_widget
-position: 1
+position: 2
 ---
 
 # Walkthrough
 
 The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) is a powerful component of the Kendo UI toolkit and an essential part of almost any user interface. The Grid control is quick to set up and is packed with features such as [sorting](/api/javascript/ui/grid#configuration-sortable), [grouping](/api/javascript/ui/grid#configuration-groupable), [paging](/api/javascript/ui/grid#configuration-pageable), and [editing](/api/javascript/ui/grid#events-edit).
-
-## Initialize the Grid
-
-Use either of the two primary approaches to create Kendo UI Grids:
-
-* From empty `<div>` elements&mdash;in this case all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
-* From HTML tables&mdash;in this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
-* In hidden containers&mdash;when you initialize a scrollable Grid with a set height in a PanelBar, TabStrip, or Window, you also need to consider some additional layout specifics of the widget.
-
-### From Empty div Elements
-
-1. Start with an empty `<div>` element that has an ID.
-
-    ###### Example
-
-    ```
-    <div id="grid"></div>
-    ```
-
-2. Turn the `<div>` into a grid by selecting the `<div>` with a jQuery selector and by calling the `kendoGrid()` function.
-3. Specify the column layout by passing an array of column definition objects to the `column` option of the widget. This step is necessary because the Grid is being created based on an empty `<div>`.
-
-    ###### Example
-
-    ```
-    $("#grid").kendoGrid({
-        columns: [ { title: "First Name", field: "firstName" },
-                   { title: "Last Name", field: "lastName"},
-                   { title: "Email", field: "email" } ]
-    });
-    ```
-
-    Each column object features:
-
-    * The `title` property, which defines the text you want to appear as the column header.
-    * The `field` property, which defines the field in the data set that this column should be bound to.
-    * The `template` property, which specifies a template instead of plain text for the Grid column to display.
-    * The `width` property, which defines the desired width of the column.
-
-### From HTML Tables
-
-1. Add an HTML table.
-2. Specify the table header. Each of the `<th>` elements you specify will become a column and the text will become the column header. The `<col>` elements define the widths of the columns. The data attributes define the fields and the templates.
-
-    ###### Example
-
-    ```
-    <table id="grid">
-        <colgroup>
-            <col style="width:100px" />
-            <col style="width:200px" />
-            <col />
-        </colgroup>
-        <thead>
-            <tr>
-                <th data-field="firstName">First Name</th>
-                <th data-field="lastName">Last Name</th>
-                <th data-field="email" data-template="<a href='mailto:#= email #'>#= email #</a>">Email</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Nancy</td>
-                <td>Davolio</td>
-                <td>email@domain.com</td>
-            </tr>
-        </tbody>
-    </table>
-    ```
-
-    The table can now describe the entire structure of the grid. The field in the data set to which the column is bound is specified in the `data-field` attribute of each `<th>` element. It is strongly recommended to use the `data-field` attributes. Otherwise the content of the header cell has to meet the [requirements for data field names](/api/javascript/ui/grid#configuration-columns.field).
-
-3. Because the layout of the Grid is defined by the HTML, you only have to call the `kendoGrid()` function to create the Grid.
-
-    ###### Example
-
-    ```
-    $("#grid").kendoGrid();
-    ```
-
-    When you create the Grid from an existing HTML table, each row from the table is added as a data item to the dataSource of the Grid. As a result, your Grid is populated with the content from the table and reflects the information it contains.
-
-For more information on initializing the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}).
-
-### In Hidden Containers
-
-If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
-
-When you handle the initialization of the Grid in hidden containers, it is possible to use some general as well as specific approaches depending on the particular scenario.
-
-For more information on initializing the Grid inside hidden containers and the approaches to consider, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
 
 ## Data Binding
 

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -8,46 +8,53 @@ position: 1
 
 # Walkthrough
 
-The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) is a powerful fragment of the Kendo UI framework and an essential part of almost any user interface. The Grid control is quick to set up and is packed with features such as [sorting](/api/javascript/ui/grid#configuration-sortable), [grouping](/api/javascript/ui/grid#configuration-groupable), [paging](/api/javascript/ui/grid#configuration-pageable), and [editing](/api/javascript/ui/grid#events-edit).
+The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) is a powerful component of the Kendo UI toolkit and an essential part of almost any user interface. The Grid control is quick to set up and is packed with features such as [sorting](/api/javascript/ui/grid#configuration-sortable), [grouping](/api/javascript/ui/grid#configuration-groupable), [paging](/api/javascript/ui/grid#configuration-pageable), and [editing](/api/javascript/ui/grid#events-edit).
 
 ## Initialize the Grid
 
-To initialize a Kendo UI Grid, use either of the following primary approaches:
+Use either of the two primary approaches to create Kendo UI Grids:
 
-* From an empty `<div>` element&mdash;in this case all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
-* From an HTML table&mdash;in this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
+* From empty `<div>` elements&mdash;in this case all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
+* From HTML tables&mdash;in this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
 
-### From HTML Element: `<div>`
+### From Empty `<div>` Elements
 
-First start with an empty `<div>` element that has an ID.
+1. Start with an empty `<div>` element that has an ID.
 
-###### Example
+    ###### Example
 
+    ```
     <div id="grid"></div>
+    ```
 
-Now turn the `<div>` into a grid by selecting the `<div>` with a jQuery selector, and calling the `kendoGrid()` function. Since the Grid is being created based on an empty `<div>`, you have to specify the column layout by passing an array of column definition objects to the column option of the widget.
+2. Turn the `<div>` into a grid by selecting the `<div>` with a jQuery selector and by calling the `kendoGrid()` function.
+3. Specify the column layout by passing an array of column definition objects to the `column` option of the widget. This step is necessary because the Grid is being created based on an empty `<div>`.
 
-###### Example
+    ###### Example
 
+    ```
     $("#grid").kendoGrid({
         columns: [ { title: "First Name", field: "firstName" },
                    { title: "Last Name", field: "lastName"},
                    { title: "Email", field: "email" } ]
     });
+    ```
 
-Each column object has the following properties:
+    Each column object features:
 
-1. `title`&mdash;this is the text you want to appear as the column header.
-2. `field`&mdash;the field in the data set that this column should be bound to.
-3. `template`&mdash;you can specify a template for the Grid column to display instead of plain text.
-4. `width`&mdash;the desired width of the column.
+    * The `title` property, which defines the text you want to appear as the column header.
+    * The `field` property, which defines the field in the data set that this column should be bound to.
+    * The `template` property, which specifies a template instead of plain text for the Grid column to display.
+    * The `width` property, which defines the desired width of the column.
 
-### From HTML Table
+### From HTML Tables
 
-Add an HTML table. Specify the table header. Each of the `<th>` elements you specify will become a column and the text will become the column header. Column widths can be set through the `<col>` elements. Fields and templates are defined through the data attributes.
+1. Add an HTML table.
+2. Specify the table header. Each of the `<th>` elements you specify will become a column and the text will become the column header. The `<col>` elements define the widths of the columns. The data attributes define the fields and the templates.
 
-###### Example
+    ###### Example
 
+    ```
     <table id="grid">
         <colgroup>
             <col style="width:100px" />
@@ -69,24 +76,40 @@ Add an HTML table. Specify the table header. Each of the `<th>` elements you spe
             </tr>
         </tbody>
     </table>
+    ```
 
-The table can now describe the entire structure of the grid. The field that the column is bound to in the data set is specified in the `data-field` attribute of each `<th>` element. Using `data-field` attributes is highly recommended. Otherwise the content of the header cell has to meet the [requirements for data field names](/api/javascript/ui/grid#configuration-columns.field).
+    The table can now describe the entire structure of the grid. The field in the data set to which the column is bound is specified in the `data-field` attribute of each `<th>` element. It is strongly recommended to use the `data-field` attributes. Otherwise the content of the header cell has to meet the [requirements for data field names](/api/javascript/ui/grid#configuration-columns.field).
 
-Since the layout of the Grid is defined by the HTML, you only have to call the `kendoGrid()` function to create a grid.
+3. Because the layout of the Grid is defined by the HTML, you only have to call the `kendoGrid()` function to create the Grid.
 
-###### Example
+    ###### Example
 
+    ```
     $("#grid").kendoGrid();
+    ```
 
-When you create the Grid from an existing HTML table, each row from the table is added as a data-item to the dataSource of the Grid. As a result, your Grid is populated with the content from the table to reflect the information it contains.
+    When you create the Grid from an existing HTML table, each row from the table is added as a data item to the dataSource of the Grid. As a result, your Grid is populated with the content from the table and reflects the information it contains.
 
-For more information on how to create a Grid, refer to [the overview article of the Grid]({% slug overview_kendoui_grid_widget %}).
+For more information on initializing the Grid, refer to [its introductory article]({% slug overview_kendoui_grid_widget %}).
 
 ## Data Binding
 
-### Bind to Local Data
+### Configure Auto Binding
 
-The next step is to bind the Grid to data. The widget can be bound to local data by setting the `dataSource` option of the `kendoGrid` object.
+By default, the Grid is set to automatically bind to data&mdash;as soon as it is loaded, it causes the data source to query, and the data is loaded to the Grid.
+
+To disable this behavior, set the `autoBind` option of the widget to `false`, as shown below.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        autoBind: false,
+        // other configuration
+    });
+
+### Bind to Local Arrays
+
+To bind the Grid to local data, set the `dataSource` option of the `kendoGrid` object.
 
 ###### Example
 
@@ -113,9 +136,9 @@ The next step is to bind the Grid to data. The widget can be bound to local data
 
 ### Bind to Remote Data
 
-The Grid can be bound to remote data by specifying the `dataSource` option. The data source can either be created outside the grid, or passed in it.
+To bind the Grid to remote data, specify the `dataSource` option. It is possible to either create the data source outside the widget, or to pass it in it.
 
-If you have multiple widgets bound to the same set of data, you have to create the data source as an object that you can refer to in different widgets. If the Grid is the only item bound to the data, create it inline.
+If multiple widgets are bound to the same data set, you have to create the data source as an object that you can refer to in different widgets. If the Grid is the only item bound to the data, create it inline.
 
 ###### Example
 
@@ -130,178 +153,209 @@ If you have multiple widgets bound to the same set of data, you have to create t
          }
     });
 
-For more information on binding the Grid to a remote data source, refer to [this article]({% slug remote_data_binding_grid %})
+For more information on this topic, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}).
 
-### Auto Binding
+## Height
 
-By default, the Grid is set to automatically bind to data&mdash;it will cause the data source to query as soon as it is loaded, and the data will be loaded into the Grid.
+By default, the Grid has no height and expands to fit all table rows. To provide for a backwards compatibility, the scrollable MVC wrapper of the Grid [applies a default height of 200px to its scrollable data area](/aspnet-mvc/helpers/grid/configuration#scrolling). To control the height of the widget, specify a static pixel value.
 
-To disable this behavior, set the `autoBind` option of the widget to `false`, as shown below.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        autoBind: false,
-        // other configuration
-    });
-
-## Size
-
-By default, the Grid has no height and expands vertically to fit its contents. To provide backwards compatibility, the scrollable MVC wrapper of the Grid applies a height of 200px to its scrollable data area. You can control the height of the widget by specifying a static pixel value.
-
-###### Example
-
-    $("#grid").kendoGrid({
-        height: 100,
-        // other configuration
-    });
+When the height of the Grid is set, it calculates the appropriate height of its scrollable data area, so that the sum of the header rows, filter row, data, footer, and pager is equal to the expected height of the widget.
 
 **Figure 2. Grid with a fixed height and its scrolling functionality enabled**
 
 ![Grid with fixed height and scrolling](/controls/data-management/grid/grid3_1.png)
 
-Similar to all block elements, the Grid expands to a 100% width. The width of the Grid can be controlled by setting the CSS width properties for the Grid itself or for some of its ancestors. If you use hierarchy and unless the detail template is scrollable, the detail template has to be narrower than the total width of all master columns.
+For more information on setting the height, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#height).
+
+### Let the Height Vary within Limits
+
+It is possible to make the Grid expand and shrink vertically according to the number of its rows and yet within certain limits. To achieve this, apply a minimum and/or maximum height style to the scrollable data area and do not set any height of the Grid.
+
+For more information on setting the height vary within limits, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#let-the-height-vary-within-limits).
 
 ### Set a 100% Height and Auto-Resize
 
-This section is applicable to scrollable Grids only.
+To make the Grid 100% high and resize together with its parent, you need to apply a 100% height style to the widget. According to web standards, elements with a percentage height require that their parent has an explicit height. Elements that are 100% high cannot have margins, paddings, borders, or sibling elements. That is why you have to remove the default border of the Grid as well.
 
-To configure the height of the Grid to 100% and make it resize together with its parent element, configure the `<div>` of the Grid to a 100-percent height. According to web standards, elements with a percentage height require that their parent has an explicit height. This requirement applies recursively until either an element with a pixel height or the `html` element is reached. Elements of 100-percent height cannot have margins, paddings, borders, or sibling elements. That is why you have to remove the default border of the Grid as well.
+Then, you need to make sure that the inner layout of the Grid adapts to changes in the height of the `<div>` wrapper.
 
-Then subscribe to `resize` event of the browser window and execute the [`resize`]({% slug responsivewebdesign_integration_kendoui %}) method of the Grid.
+If the Grid is placed inside a Kendo UI Splitter or Kendo UI Window, you do not need to call the `resize` method because these widgets will execute it automatically.
 
-If the ing functionality of the Grid is used, execute the code below instead of the `resize` configuration option.
+If the vertical space that is available for the Grid depends on a custom resizing of the layout, which is controlled by the user, use a suitable event or method related to the layout changes to execute the `resize` method of the Grid.
 
-###### Example
+The `resize` method works for the Kendo UI versions delivered after the Kendo UI Q3 2013 release.
 
-    $("#GridID").data("kendoGrid").dataSource.fetch();
+For more information on setting the height to 100% and auto-resize the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#set-100-height-and-auto-resize).
 
-The code from this example helps measure the total height of the Grid and adjust the height of the scrollable data area.
+### Configure the Loading Indicator
 
-If you use locked&mdash;or frozen&mdash;columns in the Grid, you do not need to apply the `resize` method.
+Internally, the Grid uses the [`kendo.ui.progress`](/api/javascript/ui/ui#methods-progress) method to display a loading overlay during remote `read` requests.
 
-The `resize` method works for Kendo UI versions delivered after the Kendo UI Q3 2013 release. For older versions, use the JavaScript code from the example below (instead of `resize`), because it practically achieves the same behavior.
+If the scrolling functionality of the Grid is disabled, the overlay is displayed over the whole Grid. If scrolling is enabled, the overlay is displayed over the scrollable data area.
 
-###### Example
+For more information on initializing the Grid inside hidden containers, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#configure-the-loading-indicator).
 
-    $(window).resize(function() {
-        var gridElement = $("#grid"),
-            newHeight = gridElement.innerHeight(),
-            otherElements = gridElement.children().not(".k-grid-content"),
-            otherElementsHeight = 0;
+## Width
 
-        otherElements.each(function(){
-            otherElementsHeight += $(this).outerHeight();
-        });
+By default, the Grid has no width and behaves like a block-level element. This means that similar to all block elements it expands to a 100% width, that is, to the width of its parent element.
 
-        gridElement.children(".k-grid-content").height(newHeight - otherElementsHeight);
-    });
+The width of the Grid can be controlled by setting the CSS width properties for the Grid itself or for some of its ancestors. If you use hierarchy and unless the detail template is scrollable, the detail template has to be narrower than the total width of all master columns.
 
-### Initialize inside Hidden Containers
+If you enable the scrolling functionality of the Grid and the sum of all column widths is greater than the width of the Grid, a horizontal scrollbar appears.
 
-If a scrollable Grid with a set height is initialized inside a hidden container, the Grid will not be able to adjust its vertical layout correctly, because the JavaScript size calculations do not work for elements of a `display:none` style. Depending on the exact configuration, the widget may appear smaller than expected, or the scrollable data area may overflow.
+If you disable the scrolling functionality of the Grid and the columns do not fit, they overflow the `<div>` element of the Grid.
 
-If you apply [virtual scrolling]({% slug walkthrough_kendoui_grid_widget%}#virtual-scrolling), the vertical scrollbar will not appear.
+For more information on configuring the width of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#width).
 
-If you do not apply virtual scrolling, apply any of the following options:
+## Columns
 
-* Initialize the Grid when its element becomes visible.
-* Manually adjust the layout of the Grid. Apply the code from the above example if you use an old Kendo UI version. You do not need to attach a window `resize` handler. As of Kendo UI Q3 2013 release onwards, you are able use [`kendo.resize()`](/api/javascript/kendo#methods-resize) or the [`resize()`]({% slug responsivewebdesign_integration_kendoui %}#individual-widget-resizing) method of the Grid.
-* Instead of setting an overall height for the Grid in its configuration, define the height for the scrollable data area only. In this case no height calculations are made.
+### Column Widths
 
-###### Example
+The columns of the Grid behave differently, depending on whether scrolling is enabled, or not.
 
-        #GridID .k-grid-content
-        {
-            height: 270px;
-        }
+By default, scrolling is enabled&mdash;except for the MVC wrapper of the Grid&mdash;and the `table-layout` style of the Grid tables is set to `fixed`. This means that all columns without a defined width will appear equally wide no matter what their content is.
 
-If you use virtual scrolling and the Grid is initialized while hidden, you have to re-fetch its dataSource when the widget becomes visible. This also readjusts the height of the scrollable data area and no other configuration is required.
+When scrolling is disabled, the `table-layout` style is set to `auto`, which is the default behavior of HTML tables. This means that if not explicitly set, the column widths are determined by the browser and by the cell content.
 
-###### Example
+For more information on configuring the column widths of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#column-widths).
 
-    $("#GridID").data("kendoGrid").dataSource.fetch();
+### Column Resizing
 
-### Column Width
+When scrolling is disabled and a column is resized, other columns change widths too, so that the sum of all column widths remains constant. If both the columns and the Grid `<div>` already have their minimum possible widths applied, then the resizing of the columns stops working. In such scenarios, either apply a larger width to the Grid, or enable scrolling.
 
-By default, the scrolling functionality is enabled&mdash;except for the Grid MVC wrapper&mdash;and the `table-layout` style of the Grid tables is set to `fixed`. This means that all columns without a defined width will appear equally wide no matter what their content is. All set column widths will be obeyed regardless of the cell content. If the content cannot fit, it will be either wrapped or clipped.
+For more information on resizing the columns of the Grid, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#column-resizing).
 
-When the scrolling functionality is disabled, the `table-layout` style is set to `auto`. This means that if not explicitly set, the column widths are determined by the browser and by the cell content. The browser will try to obey all column widths that are set, but may readjust some columns depending on their content.
+### Locked Columns
 
-If needed, apply a fixed table layout to a non-scrollable Grid.
+Locked (frozen) columns allow part of the columns to be visible at all times during horizontal Grid scrolling.
 
-###### Example
+The Grid allows you to lock columns on one side of the table. For the feature to work properly, provide the following configuration settings:  
 
-    #GridID > table /* header + data table */
-    {
-        table-layout: fixed;
-    }
+* Enable [scrolling]({% slug appearance_kendoui_grid_widget %}#scrolling).
+* Lock at least one column initially.
+* Define the height of the Grid.
+* Set explicit pixel widths to all columns to allow the Grid to adjust the layout of the frozen and non-frozen table parts.
+* Make sure that the total width of all locked columns is equal to or less than the width of the Grid minus three times the width of the scrollbar.
 
-<!--*-->
-When you create a grid from an HTML `table`, you can set the width of the columns through the `col` elements.
+These settings ensure that at least one non-locked column is always visible and that it is possible to scroll the non-locked columns horizontally.
 
-If [scrolling](#scrolling) is enabled, and all columns have pixel widths and their sum exceeds the width of the Grid, a horizontal scrollbar appears.
+The row template and detail features are not supported in combination with column locking. It is possible to lock a column at the topmost level only, if you use [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders).
 
-If that sum is less than the width of the Grid, the column widths are ignored and all columns are expanded. This leads to undesired side effects&mdash;for example, when resizing columns. In old Internet Explorer versions the column widths are obeyed, but misalignment occurs. That is why it is recommended to have at least one column without a specified width. Set an explicit width for all columns only if they are set in percent, or if their sum exceeds the width of the Grid and you want to achieve horizontal scrolling.
+Frozen columns cannot be touch-scrolled, because they are wrapped in a container with an `overflow:hidden` style.
 
-If scrolling is enabled, and the Grid has no fixed width and resizes together with the browser window, apply a minimum width to its table elements. This prevents undesired side effects if the browser window size is reduced too much.
+For more information on locking columns, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#locked-columns).
 
-The example below demonstrates how to apply a minimum width to the table elements when the scrolling functionality is enabled.
+### Column Templates
 
-###### Example
+Columns need additional specific templating when they represent complex displays and not single fields.
 
-    #GridID .k-grid-header-wrap > table, /* header table */
-    #GridID .k-grid-content > table, /* data table, no virtual scrolling */
-    #GridID .k-virtual-scrollable-wrap > table /* data table, with virtual scrolling */
-    {
-        min-width: 800px;
-    }
+For more information on configuring columns by using templates in the Grid, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}#set-the-column-template).
 
-<!--*-->
-If scrolling is disabled, and the Grid has no fixed width and resizes together with the browser window, apply a minimum width to the widget.
+## Rows
 
-The example below demonstrates how to apply a minimum width to the Grid when the scrolling functionality is disabled.
+### Rows by Model IDs
 
-###### Example
+It is possible to get a table row in the Grid by the data item ID.
 
-    #GridID /* or use the .k-grid class to apply to all Grids */
-    {
-        min-width: 800px;
-    }
+For more information on how to retrieve rows by a model ID, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#rows-by-model-ids).
 
-<!--*-->
-Using the `Grid ID` (Name) in the above selectors is optional, so that the styles are applied to a particular Grid instance only.
+### Custom Rows When No Records Are Loaded
 
-### Use Wide Non-Scrollable Grids
+It is possible to manually add a table row with some user-friendly message when the dataSource does not return any data&mdash;for example, as a result of filtering.
 
-Basically, the Grid is a `<table>` element inside a `<div>` one. Tables can expand horizontally beyond 100% to enclose their content, while `<div>` elements lack this behavior. As a result, if the scrolling functionality of the Grid is disabled, the widget `<table>` might overflow the wrapper `<div>` and lead to a visual glitch.
+For more information on adding custom rows when no records are loaded, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#custom-rows-when-no-records-are-loaded).
 
-The possible solutions for you to apply to handle table overflowing are:
+### Row Templates  
 
-* Enable the scrolling functionality, which, by default, is disabled when using the Kendo UI Grid MVC wrapper.
-* Set a large-enough width or a min-width style for the `<div>` wrapper of the Grid.
-* Float the `<div>` wrapper of the Grid and clear the float right after the widget. Floated elements expand and shrink automatically to enclose their content when needed.
+It is possible to format any cell in the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
+
+**Figure 3. Grid with a row template applied**
+
+![Grid With Row Template](/controls/data-management/grid/grid8_1.png)
+
+For more information on using row templates, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#row-templates).
 
 ## Features
 
-### Virtual Scrolling
+### Selection
 
-Virtual scrolling is an alternative to paging. When enabled, the Grid loads data from the remote data source as the user scrolls vertically.
+To enable selection in the Grid, set the [`selectable`](/api/javascript/ui/grid#configuration-selectable) option to `true`. This enables the default single-row selection option.
+
+**Figure 4. Grid with enabled row selection**
+
+![Grid with enabled row selection](/controls/data-management/grid/grid4_1.png)
+
+It is also possible to set the `selectable` option to any of the following values:
+* `row`
+* `cell`
+* `multiple row`
+* `multiple cell`
+
+For more information on the selection functionality and its limitations, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Selection).
+
+### Paging
+
+To configure the paging functionality of the Grid, use Boolean configuration options. By default, paging&mdash;as well as grouping and sorting&mdash;are disabled, while scrolling is enabled.
+
+The paging function of the Grid is controlled by the `pageable` option. Additionally, you have to indicate to the Grid the number of records to display on each page as well as the total number of records in the dataset. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
 
 ###### Example
 
     $("#grid").kendoGrid({
-        scrollable: {
-            virtual: true
-        },
-        // other configuration
+         pageable: true
+         // other configuration
     });
 
-For more information on virtual scrolling and its limitations, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
+For more information on paging, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Paging).
+
+### Grouping
+
+By default, grouping&mdash;as well as paging and sorting&mdash;are disabled, while scrolling is enabled.
+
+To enable the grouping functionality of the Grid, set the `groupable` option to `true`. This exposes a new area in the header, which informs that it is possible for the user to drop a column on it and in this way to group the Grid data by that column. It is also possible to do grouping by multiple columns by dragging a second column onto the grouping header.
+
+###### Example
+
+    $("#grid").kendoGrid({
+         groupable: true
+         // other configuration
+    });
+
+**Figure 5. Grid with its grouping functionality enabled**
+
+![Grid With Grouping Enabled](/controls/data-management/grid/grid5_1.png)
+
+**Figure 6. Grid with its data grouped by last name**
+
+![Grid Grouped By Last Name](/controls/data-management/grid/grid6_1.png)
+
+It is also possible to sort the grouped content by clicking on the grouping tab. In the previous example, click on **lastName** to sort the grouped data in descending order. Click it again to toggle to ascending order. Each of the individual groups themselves can be toggled from expanded to collapsed states by clicking on the arrow next to the respective header grouping.
+
+Grouping can be configured to work also with row templates and together with paging.
+
+For more information on the grouping functionality, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Grouping).
+
+### Sorting
+
+By default, sorting&mdash;as well as paging and grouping&mdash;is disabled, while scrolling is enabled.
+
+**Figure 7. Grid with its sorting functionality enabled**
+
+![Grid with Sorting Enabled](/controls/data-management/grid/grid7_1.png)
+
+Sorting is also a function that can be pushed to the server for increased performance.
+
+Sorting is supported in two formats:  
+* Single-column sorting
+* Multi-column sorting
+
+For more information on the sorting functionality, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Sorting).
 
 ### Scrolling
 
-By default, the scrolling functionality of the Grid is enabled. For historical reasons, however, the [Grid MVC wrapper]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) does not support it. To disable the scrolling functionality, set the `scrollable` option to `false`.
+By default, the scrolling functionality of the Grid is enabled. For historical reasons, however, the [Grid MVC wrapper]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) does not support it.  
+
+To disable the scrolling functionality, set the `scrollable` option to `false`.
 
 ###### Example
 
@@ -323,226 +377,41 @@ For more information on the scrolling functionality, refer to the [article on th
 
 When you enable the scrolling functionality of the Grid, its vertical scrollbar is always visible even if it is not needed. This simplifies the implementation and improves the performance of the widget.
 
-To remove the vertical scrollbar, use CSS, as shown below. When using this approach, make sure that neither the Grid, nor its data area apply fixed heights, so that they are able to shrink and expand according to the number of table rows.
+To remove the vertical scrollbar, use CSS. When using this approach, make sure that neither the Grid, nor its data area, apply fixed heights, so that they are able to shrink and expand according to the number of table rows.
+
+#### Restore Scroll Positions
+
+In some scenarios, the scroll position of the Grid might be reset when the widget is rebound. To avoid this behavior, save the scroll position in the [`dataBinding`](/api/javascript/ui/grid#events-dataBinding) event and restore it in the [`dataBound`](/api/javascript/ui/grid#events-dataBound) event.
+
+If virtual scrolling is enabled, the scrollable data container is scrolled only horizontally.
+
+### Virtual Scrolling
+
+When the Grid is bound to large datasets or when you apply large page sizes, it is important for the performance of the widget to reduce the active in-memory DOM objects.
+
+To highly optimize the binding to large sets of data, the Grid provides a built-in [UI virtualization functionality]({% slug virtualization_kendoui_combobox_widget %}).  Virtual scrolling is an alternative to paging. When enabled, the Grid loads data from the remote data source as the user scrolls vertically.
+
+To enable virtual scrolling, use the configuration demonstrated in the following example.
 
 ###### Example
 
-    #GridID .k-grid-header
-    {
-       padding: 0 !important;
-    }
-
-    #GridID .k-grid-content
-    {
-       overflow-y: visible;
-    }
-
-The `#GridID` allows the application of styles only to a particular Grid instance. To use the above styles in all Grid instances, replace the ID with the `.k-grid` CSS class.
-
-### Locked Columns
-
-Locked (frozen) columns allow part of the columns to be visible at all times during horizontal Grid scrolling.
-
-The Grid allows you to lock columns on one side of the table. For the feature to work properly, make sure the following configuration settings are provided:  
-
-* Enable [Scrolling](#scrolling).
-* Lock at least one column initially.
-* Define the height of the Grid.
-* Set explicit pixel widths to all columns.
-* Make sure that the total width of all locked columns is equal to or less than the width of the Grid minus three times the width of the scrollbar.
-
-These settings ensure that at least one non-locked column is always visible and that it is possible to scroll the non-locked columns horizontally. Note that the horizontal scrollbar will not appear if the horizontal space intended for it is not enough.
-
-The row template and detail features are not supported in combination with column locking.
-
-### Selection
-
-Enable selection in the Grid simply by setting the `selectable` option to `true`. This enables the single row selection in the Grid by default.
-
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: true,
-            // other configuration
-         });
-
-**Figure 3. Grid with its row selection functionality enabled**
-
-![Grid With Row Selection Enabled](/controls/data-management/grid/grid4_1.png)
-
-You can also set the `selectable` option to any of the following values:
-
-#### Value: row
-
-This value is set by default and enables a single row selection. It is the same as `selectable: true`.
-
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: "row",
-            // other configuration
-        });
-
-#### Value: cell
-
-The value enables individual cell selection within the Grid.
-
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: "cell",
-            // other configuration
-        });
-
-#### Value: multiple row
-
-The value allows users to select multiple rows in the Grid.
-
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: "multiple row",
-            // other configuration
-        });
-
-#### Value: multiple cell
-
-The value enables a multiple cell selection within the Grid.
-
-###### Example
-
-        $("#grid").kendoGrid({
-            selectable: "multiple cell",
-            // other configuration
-        });
-
-When the multiple selection is enabled, it is possible to select multiple rows/cells by dragging the mouse cursor to select them similar to the way you would select a block of text.
-
-> **Important**  
-> * Selection is not persisted when the Grid is rebound, that is, when paging, filtering, sorting, editing, or virtual scrolling occurs. To achieve this behavior, [use this custom implementation]({% slug howto_persist_row_selection_paging_sorting_filtering_grid %}).
->
-> * Selection performance may decrease when the page size is too large, or if no paging is used, and the Grid is rendering hundreds or thousands of items. This behavior is most frequently seen in Internet Explorer. Grouping, hierarchy, and frozen columns also have a negative impact on the selection performance, because these features make the HTML output of the Grid more complex. Therefore, it is recommended to use paging and a reasonable page size.
-
-### Paging
-
-The paging function of the Grid is controlled by the `pageable` option. You need to additionally indicate to the Grid the number of records to display on each page as well as the total number of records in the data set. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
-
-    $("#grid").kendoGrid({
-         pageable: true
-         // other configuration
-    });
-
-Try to do paging operations on the server to keep from including too much data in the HTML, which can slow down page performance. To accomplish this, set the `serverPaging` option on the data source to `true`.
-
-If you decide to use server paging, be prepared to handle the requests to the server, and respond appropriately. The data source will send the following default parameters to the server when `serverPaging` is enabled:
-
-* `top`&mdash;The number of records to send back in the response.
-* `skip`&mdash;The number of records to skip from the start of the dataset.
-
-For example, if you want to show page 3 out of a 60-record dataset split into 10 records per page, the Grid would send `skip: 20`, `top: 10`.
-
-In general, Kendo UI Grid is platform-agnostic, which means that it works with HTTP requests sending and receiving JSON payload. For example, if you want to bind the widget to a specific data subset (only to а particular page), instruct the dataSource to use [`serverPaging`](/api/javascript/data/datasource#configuration-serverPaging). In this way, it will use the received data directly. The same rule applies to the filtering, grouping, aggregation, and sorting operations.
-
-### Grouping
-
-Setting the `groupable` option to `true` turns on the grouping functionality in the Grid. You can set this option either to `true`, or `false`. By default, it is set to `false`.
-
-Once grouping is enabled, a new area in the header is exposed informing you to drop a column there so you can group the data in the Grid by that column. It is possible to group by multiple columns simply by dragging a second column onto the grouping header.
-
-    $("#grid").kendoGrid({
-         groupable: true
-         // other configuration
-    });
-
-**Figure 4. Grid with its grouping functionality enabled**
-
-![Grid With Grouping Enabled](/controls/data-management/grid/grid5_1.png)
-
-**Figure 5. Grid with its data grouped by last name**
-
-![Grid Grouped By Last Name](/controls/data-management/grid/grid6_1.png)
-
-You can additionally sort the grouped content by clicking on the grouping tab. In the example above, click on **lastName** to sort the grouped data in descending order. Click it again to toggle to ascending order. Each of the individual groups themselves can be toggled from expanded to collapsed by clicking on the arrow next to the respective header grouping.
-
-#### Grouping with row templates
-
-By definition, the row template defines the row markup explicitly, while grouping requires changing the row markup. As a result, the two features can be used at the same time only if the row template includes a script, which adds additional cells, depending on the number of existing groups.
-
-    $(document).ready(function () {
-        // "window." can be omitted if the function is defined outside the document.ready closure
-        window.getGridGroupCells = function(id) {
-            var cnt = $("#" + id).data("kendoGrid").dataSource.group().length,
-                result = "";
-
-            for (var j = 0; j < cnt; j++) {
-                result += "<td class='k-group-cell'>&nbsp;</td>";
-            }
-
-            return result;
-        }
-
-        $("#GridID").kendoGrid({
-            groupable: true,
-            rowTemplate: "<tr>" +
-                "#= getGridGroupCells('GridID') #" +
-                "<td>...</td><td>...</td><td>...</td></tr>",
-            altRowTemplate: "<tr class='k-alt'>" +
-                "#= getGridGroupCells('GridID') #" +
-                "<td>...</td><td>...</td><td>...</td></tr>"
-        });
-    });
-
-#### Grouping with paging
-
-Paging occurs before grouping. Otherwise, you need to group the whole dataSource, which will greatly reduce the performance. As a result, the following behavior is exhibited:
-
-* The dataSource instance of the Grid is not aware if there are items from the displayed groups on other pages.
-* If groups are collapsed, additional items and groups from other pages cannot be displayed below the rendered items and groups. The only possible workaround is to increase the page size.
-
-### Sorting
-
-Sorting is supported in two formats&mdash;either single-column sorting, or multi-column sorting.
-
-To enable the single-column sorting, set the `sortable` option of the Grid to `true`. This will enable the default single-column sorting:
-
-    $("#grid").kendoGrid({
-         sortable: true
-         // other configuration
-    });
-
-**Figure 6. Grid with its sorting functionality enabled**
-
-![Grid With Sorting Enabled](/controls/data-management/grid/grid7_1.png)
-
-The sortable attribute also has the following settings:
-
-#### Single-column sorting
-
-Enable single-column sorting:
-
-    $("#grid").kendoGrid({
-         sortable: true
-         // other configuration
-    });
-
-#### Multi-column sorting
-
-Enable multi-column sorting:
-
-    $("#grid").kendoGrid({
-        sortable: {
-            mode: "multiple"
-        },
-        // other configuration
-    });
-
-Sorting is also a function that can be pushed to the server for increased performance. This is done through the data source itself and setting the `serverSorting` option on the data source to `true`. When you delegate sorting to the server, be prepared to receive the default parameter which is `orderBy`. This field will contain the field name of the column to sort by in the dataset.
+       $(document).ready(function(){
+          $("#grid").kendoGrid({
+             scrollable: {
+                 virtual: true
+             }
+          });
+      });
+
+For more information on virtual scrolling and its limitations, refer to the [article on the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
 
 ### Keyboard Navigation
 
-Keyboard navigation within the Grid is supported by the `navigatable` option. When it is set to `true`, you are able to move through the Grid using the arrow keys after you have initially selected a row or a cell. The navigation occurs at a cell level regardless of what `selectable` mode is specified. The current row or cell will be selected when the space bar is pressed.
+Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
 
-The example below demonstrates how to enable the key navigation in a Kendo UI Grid.
+The navigation occurs at a cell level regardless of what the `selectable` mode is. To select the current row or cell, press the space bar.
+
+The example below demonstrates how to enable the key navigation in the Grid.
 
 ###### Example
 
@@ -551,178 +420,57 @@ The example below demonstrates how to enable the key navigation in a Kendo UI Gr
          // other configuration
     });
 
-The keyboard navigation of the Grid works by listening to `keydown` events on the wrapper element of the widget. The assumption is that everything the user does is in accordance with the currently focused Grid cell, not the focused element of the browser. If the Grid data cells contain hyperlinks and users want to activate them through the keyboard, the correct way to do that is to navigate to the respective Grid cell using the arrow keys, press `Enter` to focus the hyperlink inside the cell, and then press `Enter` again. Afterwards, pressing `Esc` will return focus to the table cell. The custom hyperlinks should have a `tabindex="-1"` attribute, so that they are inaccessible through tabbing.
+For more information on the keyboard navigation, refer to the [introductory article of the Grid]({% slug overview_kendoui_grid_widget %}#configuration-Keyboard).
 
-If needed, you can avoid the described procedure. The custom hyperlinks can be accessed through tabbing and activated through `Enter` by hacking and bypassing the keyboard navigation of the Grid. This is achieved by preventing event bubbling of the `keydown` event of the custom hyperlinks, so that the Grid never finds out about their `Enter` key-presses.
+## Hidden Containers
 
-### Rows
+If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
 
-#### Retrieve Rows by Model IDs
+For more information on initializing the Grid inside hidden containers, refer to the article on the [appearance of the Grid]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
 
-To get a Grid table row by the data item ID, follow the steps below:
+## Editing
 
-1. Make sure the [ID field is defined in the model configuration](/api/javascript/data/model#configuration-Example) of the Grid dataSource.
-2. Retrieve the row model, the model UID, and the Grid table row consecutively:
+Editing is one of the basic functionalities Kendo UI Grid supports and it allows you to manipulate the way the data is presented.
 
-    var rowModel = gridObject.dataSource.get(10249); // get method of the Kendo UI dataSource object
-    var modelUID = rowModel.get("uid"); // get method of the Kendo UI Model object
-    var tableRow = $("[data-uid='" + modelUID + "']"); // the data-uid attribute is applied to the desired table row element. This UID is rendered by the Grid automatically.
+For more information on the editing functionality, refer to the article on [editing of the Grid]({% slug editing_kendoui_grid_widget %}).
 
-#### Add Custom Rows When No Records Are Loaded
+## Adaptive Rendering
 
-When the dataSource does not return any data, for example, as a result of filtering, a table row with some user-friendly message can be manually added.
+As of the Kendo UI Q3 2013 release, the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
 
-The example below demonstrates how to add a table row in the [dataBound](/api/javascript/ui/grid#events-dataBound) event handler of the Grid.
+For more information on the responsive web design, refer to the article on the [adaptive rendering of the Grid]({% slug adaptive_rendering_kendoui_grid_widget %}).
 
-###### Example
+## Localization
 
-    function onGridDataBound(e) {
-        if (!e.sender.dataSource.view().length) {
-            var colspan = e.sender.thead.find("th:visible").length,
-                emptyRow = '<tr><td colspan="' + colspan + '">... no records ...</td></tr>';
-            e.sender.tbody.parent().width(e.sender.thead.width()).end().html(emptyRow);
-        }
-    }
+Localization is the process of adapting software to meet the requirements of local markets and different languages. Kendo widgets allow you to change the text messages that are displayed to the end user.
 
-For more detailed information on the layout options, refer to [the article about the appearance of the Grid]({% slug appearance_kendoui_grid_widget %}).    
+The Grid widget provides a way to localize the user interface by using configuration options.
 
-## Templates
+For more information on localization, refer to the article on [localizing the Grid]({% slug localization_kendoui_grid_widget %}).
 
-Using templates within a script tag, or within the template option on the column object if the Grid is initialized from a `<div>` element, can format each cell in the Grid.
+## Export to Excel
 
-The example below demonstrates how to use a template to format the email address as a hyperlink by using a template, declared in a script block.
+As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in Excel export functionality.
 
-###### Example
+For more information on Excel export and its limitations, refer to the article on [exporting the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %}).
 
-    <script id="template" type="text/x-kendo-tmpl">
-        <tr>
-            <td>
-                #= firstName #
-            </td>
-            <td>
-                #= lastName #
-            </td>
-            <td>
-                <a href="mailto:#= email #">#= email #</a>
-            </td>
-        </tr>
-    </script>
+## Export to PDF
 
-This is then specified as a template for each row by passing it in to the `rowTemplate` option on the Grid and initializing it with the `kendo.template` function:
+As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in PDF export functionality.
 
-    $("#grid").kendoGrid({
-        rowTemplate: kendo.template($("#template").html()),
-       // other configuration
-    });
-
-Now the email address is an interactive hyperlink, which will open a new email message.
-
-**Figure 7. Grid with a row template applied**
-
-![Grid With Row Template](/controls/data-management/grid/grid8_1.png)
+For more information on PDF export and its limitations, refer to the article on [exporting the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %}).
 
 ## Printing
 
-When the Grid is scrollable, which is a default option except for the Grid MVC wrapper, it renders a [separate table for the header area](#scrolling). Since the browser cannot understand the relationship between the two Grid tables, it will not repeat the header row on top of every printed page. The code below addresses this issue by cloning the header row and prepending it to the printable Grid. Another option is to [disable the scrolling functionality of the Grid](#scrolling).
+In most cases, the Grid is not the only content on a page. Yet, you might want to print the Grid only.
 
-The example below demonstrates how to inject the HTML output of the Grid in a new browser window, and trigger printing.
+To print the content of the Grid only though the widget might not be the only content on the page, use either of the options:
+* Print existing web pages
+* Print new web pages
 
-###### Example
-
-    //HTML
-    <div id="grid"></div>
-
-    <script type="text/x-kendo-template" id="toolbar-template">
-        <button type="button" class="k-button" id="printGrid">Print Grid</button>
-    </script>
-
-    //JavaScript
-	function printGrid() {
-		var gridElement = $('#grid'),
-			printableContent = '',
-			win = window.open('', '', 'width=800, height=500'),
-			doc = win.document.open();
-
-		var htmlStart =
-				'<!DOCTYPE html>' +
-				'<html>' +
-				'<head>' +
-				'<meta charset="utf-8" />' +
-				'<title>Kendo UI Grid</title>' +
-				'<link href="http://kendo.cdn.telerik.com/' + kendo.version + '/styles/kendo.common.min.css" rel="stylesheet" /> ' +
-				'<style>' +
-				'html { font: 11pt sans-serif; }' +
-				'.k-grid { border-top-width: 0; }' +
-				'.k-grid, .k-grid-content { height: auto !important; }' +
-				'.k-grid-content { overflow: visible !important; }' +
-				'.k-grid .k-grid-header th { border-top: 1px solid; }' +
-				'.k-grid-toolbar, .k-grid-pager > .k-link { display: none; }' +
-				'</style>' +
-				'</head>' +
-				'<body>';
-
-		var htmlEnd =
-				'</body>' +
-				'</html>';
-
-		var gridHeader = gridElement.children('.k-grid-header');
-		if (gridHeader[0]) {
-			var thead = gridHeader.find('thead').clone().addClass('k-grid-header');
-			printableContent = gridElement
-				.clone()
-					.children('.k-grid-header').remove()
-				.end()
-					.children('.k-grid-content')
-						.find('table')
-							.first()
-								.children('tbody').before(thead)
-							.end()
-						.end()
-					.end()
-				.end()[0].outerHTML;
-		} else {
-			printableContent = gridElement.clone()[0].outerHTML;
-		}
-
-		doc.write(htmlStart + printableContent + htmlEnd);
-		doc.close();
-		win.print();
-	}
-
-	$(document).ready(function () {
-		var grid = $('#grid').kendoGrid({
-			dataSource: {
-				type: 'odata',
-				transport: {
-					read: "http://demos.telerik.com/kendo-ui/service/Northwind.svc/Products"
-				},
-				pageSize: 20,
-				serverPaging: true,
-				serverSorting: true,
-				serverFiltering: true
-			},
-			toolbar: kendo.template($('#toolbar-template').html()),
-			height: 400,
-			pageable: true,
-			columns: [
-				{ field: 'ProductID', title: 'Product ID', width: 100 },
-				{ field: 'ProductName', title: 'Product Name' },
-				{ field: 'UnitPrice', title: 'Unit Price', width: 100 },
-				{ field: 'QuantityPerUnit', title: 'Quantity Per Unit' }
-			]
-		});
-
-		$('#printGrid').click(function () {
-			printGrid();
-		});
-
-	});
-
-For more detailed information on printing the Grid, refer to [this article]({% slug printing_kendoui_grid %}).
+For more information on printing, refer to the article on [printing the Grid]({% slug printing_kendoui_grid %}).
 
 ## See Also
-
-Other articles on the Kendo UI Grid:
 
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
 * [Editing Functionality]({% slug editing_kendoui_grid_widget %})

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -14,7 +14,7 @@ The [Kendo UI Grid widget](http://demos.telerik.com/kendo-ui/grid/index) is a po
 
 ### Configure Auto Binding
 
-By default, the Grid is set to automatically bind to data&mdash;as soon as it is loaded, it causes the data source to query, and the data is loaded to the Grid.
+By default, the Grid is set to automatically bind to data&mdash;as soon as it is loaded, it causes the [DataSource]({% slug overview_kendoui_datasourcecomponent %}) to query, and the data is loaded to the Grid.
 
 To disable this behavior, set the `autoBind` option of the widget to `false`, as shown below.
 
@@ -287,9 +287,30 @@ To enable the single-column sorting, set the `mode` option to `multiple`.
         // other configuration
     });
 
+### Keyboard Navigation
+
+Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
+
+The navigation occurs at a cell level regardless of what the `selectable` mode is. To select the current row or cell, press the space bar.
+
+The example below demonstrates how to enable the key navigation in the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+         navigatable: true
+         // other configuration
+    });
+
+The keyboard navigation of the Grid works by listening to the `keydown` events on the wrapper element of the widget. It is assumed that everything the user does is in accordance with the currently focused Grid cell, not the focused element of the browser.
+
+If the data cells of the Grid contain hyperlinks and you want to activate them through the keyboard, navigate to the respective Grid cell by using the `Arrow` keys, then press `Enter` to focus the hyperlink inside the cell, and press `Enter` again. To return the focus on the table cell, press `Esc`. In order for the hyperlinks to be inaccessible through tabbing, set the `tabindex="-1"` attribute to the custom hyperlinks.
+
+It is also possible to avoid the described procedure. The custom hyperlinks can be accessed through tabbing and activated through `Enter` by hacking and bypassing the keyboard navigation of the Grid. To achieve this, prevent the event bubbling of the `keydown` event of the custom hyperlinks. In this way, the `Enter` key-presses go unnoticed by the Grid.
+
 ## Templates
 
-### Rows
+### Row Templates
 
 It is possible to format any cell within the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
 
@@ -328,7 +349,7 @@ In the resulting Grid, the email address is an interactive hyperlink which opens
 
 For more information on the templating features in Kendo UI, refer to the [introductory article on templates in ASP.NET MVC applications]({% slug overview_kendoui_templatescomponent %}).
 
-### Columns
+### Column Templates
 
 Columns need additional specific templating when they represent complex displays and not single fields.
 

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -73,137 +73,20 @@ If multiple widgets are bound to the same data set, you have to create the data 
 
 For more information on binding the Grid to a remote data source, refer to the article on [remote data binding of the widget]({% slug remote_data_binding_grid %}).
 
-## Height
-
-By default, the Grid has no height and expands to fit all table rows. To provide for a backwards compatibility, the scrollable MVC wrapper of the Grid [applies a default height of 200px to its scrollable data area](/aspnet-mvc/helpers/grid/configuration#scrolling). To control the height of the widget, specify a static pixel value.
-
-When the height of the Grid is set, it calculates the appropriate height of its scrollable data area, so that the sum of the header rows, filter row, data, footer, and pager is equal to the expected height of the widget.
-
-**Figure 2. Grid with a fixed height and its scrolling functionality enabled**
-
-![Grid with fixed height and scrolling](/controls/data-management/grid/grid3_1.png)
-
-For more information on setting the height of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#height).
-
-### Let the Height Vary within Limits
-
-It is possible to make the Grid expand and shrink vertically according to the number of its rows and yet within certain limits. To achieve this, apply a minimum and/or maximum height style to the scrollable data area and do not set any height of the Grid.
-
-For more information on setting the height vary within limits in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#let-the-height-vary-within-limits).
-
-### Set a 100% Height and Auto-Resize
-
-To make the Grid 100% high and resize together with its parent, you need to apply a 100% height style to the widget. According to web standards, elements with a percentage height require that their parent has an explicit height. Elements that are 100% high cannot have margins, paddings, borders, or sibling elements. That is why you have to remove the default border of the Grid as well.
-
-Then, you need to make sure that the inner layout of the Grid adapts to changes in the height of the `<div>` wrapper.
-
-If the Grid is placed inside a Kendo UI Splitter or Kendo UI Window, you do not need to call the `resize` method because these widgets will execute it automatically.
-
-If the vertical space that is available for the Grid depends on a custom resizing of the layout, which is controlled by the user, use a suitable event or method related to the layout changes to execute the `resize` method of the Grid.
-
-The `resize` method works for the Kendo UI versions delivered after the Kendo UI Q3 2013 release.
-
-For more information on setting the height to 100% and auto-resize the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#set-100-height-and-auto-resize).
-
-### Configure the Loading Indicator
-
-Internally, the Grid uses the [`kendo.ui.progress`](/api/javascript/ui/ui#methods-progress) method to display a loading overlay during remote `read` requests.
-
-If the scrolling functionality of the Grid is disabled, the overlay is displayed over the whole Grid. If scrolling is enabled, the overlay is displayed over the scrollable data area.
-
-For more information on configuring the loading indicator in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#configure-the-loading-indicator).
-
-## Width
-
-By default, the Grid has no width and behaves like a block-level element. This means that similar to all block elements it expands to a 100% width, that is, to the width of its parent element.
-
-The width of the Grid can be controlled by setting the CSS width properties for the Grid itself or for some of its ancestors. If you use hierarchy and unless the detail template is scrollable, the detail template has to be narrower than the total width of all master columns.
-
-If you enable the scrolling functionality of the Grid and the sum of all column widths is greater than the width of the Grid, a horizontal scrollbar appears.
-
-If you disable the scrolling functionality of the Grid and the columns do not fit, they overflow the `<div>` element of the Grid.
-
-For more information on configuring the width of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#width).
-
-## Columns
-
-### Column Widths
-
-The columns of the Grid behave differently, depending on whether scrolling is enabled, or not.
-
-By default, scrolling is enabled&mdash;except for the MVC wrapper of the Grid&mdash;and the `table-layout` style of the Grid tables is set to `fixed`. This means that all columns without a defined width will appear equally wide no matter what their content is.
-
-When scrolling is disabled, the `table-layout` style is set to `auto`, which is the default behavior of HTML tables. This means that if not explicitly set, the column widths are determined by the browser and by the cell content.
-
-For more information on configuring the column widths of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#column-widths).
-
-### Column Resizing
-
-When scrolling is disabled and a column is resized, other columns change widths too, so that the sum of all column widths remains constant. If both the columns and the Grid `<div>` already have their minimum possible widths applied, then the resizing of the columns stops working. In such scenarios, either apply a larger width to the Grid, or enable scrolling.
-
-For more information on resizing the columns of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#column-resizing).
-
-### Locked Columns
-
-Locked (frozen) columns allow part of the columns to be visible at all times during horizontal Grid scrolling.
-
-The Grid allows you to lock columns on one side of the table. For the feature to work properly, provide the following configuration settings:  
-
-* Enable [scrolling]({% slug appearance_kendoui_grid_widget %}#scrolling).
-* Lock at least one column initially.
-* Define the height of the Grid.
-* Set explicit pixel widths to all columns to allow the Grid to adjust the layout of the frozen and non-frozen table parts.
-* Make sure that the total width of all locked columns is equal to or less than the width of the Grid minus three times the width of the scrollbar.
-
-These settings ensure that at least one non-locked column is always visible and that it is possible to scroll the non-locked columns horizontally.
-
-The row template and detail features are not supported in combination with column locking. It is possible to lock a column at the topmost level only, if you use [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders).
-
-It is not possible to scroll frozen columns by touch, because they are wrapped in a container with an `overflow:hidden` style.
-
-For more information on locking columns in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#locked-columns).
-
-### Column Templates
-
-Columns need additional specific templating when they represent complex displays and not single fields.
-
-For more information on configuring columns by using templates in the Grid, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}#set-the-column-template).
-
-For more information on the templating features in Kendo UI, refer to the [introductory article on templates]({% slug overview_kendoui_templatescomponent %}).
-
-## Rows
-
-### Model IDs
-
-It is possible to get a table row in the Grid by the ID of the data item.
-
-For more information on how to retrieve rows by a model ID in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#rows-by-model-ids).
-
-### Custom Rows When No Records Are Loaded
-
-It is possible to manually add a table row with some user-friendly message when the dataSource does not return any data&mdash;for example, as a result of filtering.
-
-For more information on adding custom rows when no records are loaded in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#custom-rows-when-no-records-are-loaded).
-
-### Row Templates  
-
-It is possible to format any cell in the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
-
-**Figure 3. Grid with a row template applied**
-
-![Grid With Row Template](/controls/data-management/grid/grid8_1.png)
-
-For more information on using row templates in the Grid, refer to the article on its [appearance]({% slug appearance_kendoui_grid_widget %}#row-templates).
-
-For more information on the templating features in Kendo UI, refer to the [introductory article on templates]({% slug overview_kendoui_templatescomponent %}).
-
-## Features
+## Configuration
 
 ### Selection
 
 To enable selection in the Grid, set the [`selectable`](/api/javascript/ui/grid#configuration-selectable) option to `true`. This enables the default single-row selection option.
 
-**Figure 4. Grid with enabled row selection**
+###### Example
+
+        $("#grid").kendoGrid({
+            selectable: true,
+            // other configuration
+         });
+
+**Figure 2. Grid with enabled row selection**
 
 ![Grid with enabled row selection](/controls/data-management/grid/grid4_1.png)
 
@@ -213,13 +96,63 @@ It is also possible to set the `selectable` option to any of the following value
 * `multiple row`
 * `multiple cell`
 
-For more information on the selection functionality and its limitations in the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Selection).
+#### The row Value
+
+The `row` value is set by default and enables a single row selection. It functions in the same way as the `selectable: true` configuration.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "row",
+        // other configuration
+    });
+
+#### The cell Value
+
+The `cell` value enables the selection of individual cells within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "cell",
+        // other configuration
+    });
+
+#### The multiple row Value
+
+The `multiple row` value allows users to select multiple rows within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "multiple row",
+        // other configuration
+    });
+
+#### The multiple cell Value
+
+The `multiple cell` value enables the selection of multiple cells within the Grid.
+
+###### Example
+
+    $("#grid").kendoGrid({
+        selectable: "multiple cell",
+        // other configuration
+    });
+
+When the multiple selection is enabled, it is possible to select multiple rows or cells by dragging the mouse cursor and select them in a similar way to a block of text.
+
+> **Important**  
+> * Selection is not persisted when the Grid is rebound, that is, when paging, filtering, sorting, editing, or virtual scrolling occurs. To achieve such behavior, [use this custom implementation]({% slug howto_persist_row_selection_paging_sorting_filtering_grid %}).
+> * Selection performance may decrease when the page size is too large, or if no paging is used, and the Grid is rendering hundreds or thousands of items. This behavior is most frequently seen in Internet Explorer. Grouping, hierarchy, and frozen columns also have a negative impact on the selection performance, because these features make the HTML output of the Grid more complex. Therefore, it is recommended to use paging and a reasonable page size.
 
 ### Paging
 
-To configure the paging functionality of the Grid, use Boolean configuration options. By default, paging&mdash;as well as grouping and sorting&mdash;are disabled, while scrolling is enabled.
+By default, paging is disabled.
 
-The paging function of the Grid is controlled by the `pageable` option. Additionally, you have to indicate to the Grid the number of records to display on each page as well as the total number of records in the dataset. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
+The paging functionality of the Grid is controlled by the `pageable` option. To configure it, use Boolean parameters.
+
+Additionally, you have to indicate to the Grid the number of records to display on each page as well as the total number of records in the dataset. Specify the `pageSize` on the data source and the field in the dataset that will contain the total count of records.
 
 ###### Example
 
@@ -228,11 +161,31 @@ The paging function of the Grid is controlled by the `pageable` option. Addition
          // other configuration
     });
 
-For more information on the paging functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Paging).
+Try to do paging operations on the server to keep away from including too much data in the HTML, which might slow down page performance. To accomplish this, set the `serverPaging` option on the data source to `true`.
+
+If you decide to use server paging, be prepared to handle the requests to the server, and respond appropriately. When `serverPaging` is enabled, the data source will send the following default parameters to the server:
+
+* The `top` parameter defines the number of records to send back in the response.
+* The `skip` parameter defines the number of records to skip from the start of the dataset.
+
+For example, if you want to show page 3 out of a 60-record dataset split into 10 records per page, the Grid will send `skip: 20`, `top: 10`.
+
+In general, the Grid is platform-agnostic. This means that it works with HTTP requests sending and receiving JSON payload. For example, to bind the widget to a specific data subset (only to а particular page), instruct the dataSource to use [`serverPaging`](/api/javascript/data/datasource#configuration-serverPaging). In this way, it will directly use the received data. The same rule applies to the filtering, grouping, aggregation, and sorting operations.
+
+###### Example
+
+       $(document).ready(function(){
+          $("#grid").kendoGrid({
+             groupable: true,
+             scrollable: true,
+             sortable: true,
+             pageable: true
+          });
+      });
 
 ### Grouping
 
-By default, grouping&mdash;as well as paging and sorting&mdash;are disabled, while scrolling is enabled.
+By default, grouping is disabled.
 
 To enable the grouping functionality of the Grid, set the `groupable` option to `true`. This exposes a new area in the header, which informs that it is possible for the user to drop a column on it and in this way to group the Grid data by that column. It is also possible to do grouping by multiple columns by dragging a second column onto the grouping header.
 
@@ -243,199 +196,164 @@ To enable the grouping functionality of the Grid, set the `groupable` option to 
          // other configuration
     });
 
-**Figure 5. Grid with its grouping functionality enabled**
+**Figure 3. Grid with its grouping functionality enabled**
 
 ![Grid With Grouping Enabled](/controls/data-management/grid/grid5_1.png)
 
-**Figure 6. Grid with its data grouped by last name**
+**Figure 4. Grid with its data grouped by last name**
 
 ![Grid Grouped By Last Name](/controls/data-management/grid/grid6_1.png)
 
 It is also possible to sort the grouped content by clicking on the grouping tab. In the previous example, click on **lastName** to sort the grouped data in descending order. Click it again to toggle to ascending order. Each of the individual groups themselves can be toggled from expanded to collapsed states by clicking on the arrow next to the respective header grouping.
 
-Grouping can be configured to work also with row templates and together with paging.
+Grouping can be configured to work also with:
+* Row templates
+* Paging
 
-For more information on the grouping functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Grouping).
+#### Grouping with Row Templates
+
+By definition, a row template explicitly defines the row markup, while grouping requires changing the row markup. As a result, the two features can be used at the same time only if the row template includes a script which, depending on the number of existing groups, adds additional cells.
+
+###### Example
+
+    $(document).ready(function () {
+        // "window." can be omitted if the function is defined outside the document.ready closure
+        window.getGridGroupCells = function(id) {
+            var cnt = $("#" + id).data("kendoGrid").dataSource.group().length,
+                result = "";
+
+            for (var j = 0; j < cnt; j++) {
+                result += "<td class='k-group-cell'>&nbsp;</td>";
+            }
+
+            return result;
+        }
+
+        $("#GridID").kendoGrid({
+            groupable: true,
+            rowTemplate: "<tr>" +
+                "#= getGridGroupCells('GridID') #" +
+                "<td>...</td><td>...</td><td>...</td></tr>",
+            altRowTemplate: "<tr class='k-alt'>" +
+                "#= getGridGroupCells('GridID') #" +
+                "<td>...</td><td>...</td><td>...</td></tr>"
+        });
+    });
+
+#### Grouping with Paging
+
+Paging occurs before grouping. As a result, the following behavior is exhibited:
+
+* The dataSource instance of the Grid is not aware if there are items from the displayed groups on other pages.
+* If the groups are collapsed, it is not possible to display additional items and groups from other pages below the rendered items and groups. The only workaround is to increase the page size.
+
+To configure the Grid so that grouping occurs before paging, you need to group the whole dataSource. However, this setup is not recommended because it leads to a greatly reduced performance.
 
 ### Sorting
 
-By default, sorting&mdash;as well as paging and grouping&mdash;is disabled, while scrolling is enabled.
+By default, sorting is disabled.
 
-**Figure 7. Grid with its sorting functionality enabled**
+**Figure 5. Grid with its sorting functionality enabled**
 
 ![Grid with Sorting Enabled](/controls/data-management/grid/grid7_1.png)
 
-Sorting is also a function that can be pushed to the server for increased performance.
+Sorting is also a function that can be pushed to the server for increased performance. This is done through the data source itself and by setting the `serverSorting` option on the data source to `true`. When you delegate the sorting to the server, you will receive the default `orderBy` parameter. This field will contain the field name of the column to sort by in the dataset.
 
 Sorting is supported in two formats:  
 * Single-column sorting
 * Multi-column sorting
 
-For more information on the sorting functionality of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Sorting).
+#### Single-Column Sorting
 
-### Editing
-
-Editing is one of the basic functionalities Kendo UI Grid supports and it allows you to manipulate the way the data is presented.
-
-To set up the editing functionality of the Grid:
-* Configure the dataSource of the widget.
-* Declare the definitions of the fields through the `schema` option of the dataSource.
-* Set the `editable` configuration option.
-
-When editing the Grid, it is possible to work with:
-* Foreign key columns
-* Custom editors
-
-For more information on the editing functionality of the Grid, refer to the article on [editing of the widget]({% slug editing_kendoui_grid_widget %}).
-
-### Scrolling
-
-By default, the scrolling functionality of the Grid is enabled. For historical reasons, however, the [Grid MVC wrapper]({% slug configuration_gridhelper_aspnetmvc %}#scrolling) does not support it.  
-
-To disable the scrolling functionality, set the `scrollable` option to `false`.
+To enable the single-column sorting, set the `sortable` option of the Grid to `true`. This enables the default single-column sorting.
 
 ###### Example
 
     $("#grid").kendoGrid({
-        scrollable: false,
-        // other configuration
-    });
-
-Though the scrolling functionality is enabled, the scrollbars do not necessarily appear. The reason for this is that scrolling requires you to define some of the Grid dimensions:
-
-1. To achieve vertical scrolling, set the height of the Grid. Otherwise, it will expand vertically to show all rows.
-1. To achieve horizontal scrolling, explicitly define the width of all columns in pixels and make sure their sum exceeds the width of the Grid.
-
-It is possible for you to control vertical and horizontal scrolling independently.
-
-For more information on the scrolling functionality of the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#scrolling).
-
-#### Remove Vertical Scrollbar
-
-When you enable the scrolling functionality of the Grid, its vertical scrollbar is always visible even if it is not needed. This simplifies the implementation and improves the performance of the widget.
-
-To remove the vertical scrollbar, use CSS. When using this approach, make sure that neither the Grid, nor its data area, apply fixed heights, so that they are able to shrink and expand according to the number of table rows.
-
-#### Restore Scroll Positions
-
-In some scenarios, the scroll position of the Grid might be reset when the widget is rebound. To avoid this behavior, save the scroll position in the [`dataBinding`](/api/javascript/ui/grid#events-dataBinding) event and restore it in the [`dataBound`](/api/javascript/ui/grid#events-dataBound) event.
-
-If virtual scrolling is enabled, the scrollable data container is scrolled only horizontally.
-
-### Virtual Scrolling
-
-When the Grid is bound to large datasets or when you apply large page sizes, it is important for the performance of the widget to reduce the active in-memory DOM objects.
-
-To highly optimize the binding to large sets of data, the Grid provides a built-in [UI virtualization functionality]({% slug virtualization_kendoui_combobox_widget %}).  Virtual scrolling is an alternative to paging. When enabled, the Grid loads data from the remote data source as the user scrolls vertically.
-
-To enable virtual scrolling, use the configuration demonstrated in the following example.
-
-###### Example
-
-       $(document).ready(function(){
-          $("#grid").kendoGrid({
-             scrollable: {
-                 virtual: true
-             }
-          });
-      });
-
-For more information on the virtual scrolling and its limitations in the Grid, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#virtual-scrolling).
-
-### Keyboard Navigation
-
-Keyboard navigation within the Grid is configured through the `navigatable` option. When set to `true`, it is possible to initially select a row or a cell and then move through the Grid by using the `Arrow` keys.
-
-The navigation occurs at a cell level regardless of what the `selectable` mode is. To select the current row or cell, press the space bar.
-
-The example below demonstrates how to enable the key navigation in the Grid.
-
-###### Example
-
-    $("#grid").kendoGrid({
-         navigatable: true
+         sortable: true
          // other configuration
     });
 
-For more information on the keyboard navigation of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Keyboard).
+#### Multi-Column Sorting
 
-## Export
+To enable the single-column sorting, set the `mode` option to `multiple`.
 
-### Excel
+###### Example
 
-As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in Excel export functionality.
+    $("#grid").kendoGrid({
+        sortable: {
+            mode: "multiple"
+        },
+        // other configuration
+    });
 
-The Excel export of the Grid provides the following options and support:
-* Export of all data
-* Customization of the generated Excel document
-* Reversion of the cells and Right-to-Left (RTL) support
-* Row types
-* Export of multiple Grids
-* Saving files on the server
-* Export of huge data sets to Excel
+## Templates
 
-For more information on the Excel export of the Grid and its limitations, refer to the article on [exporting of the widget to Excel]({% slug exporting_excel_kendoui_grid_widget %}).
+### Rows
 
-### PDF
+It is possible to format any cell within the Grid by using templates within a script tag or within the template option on the column object if the Grid is initialized from a `<div>` element.
 
-As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in PDF export functionality.
+The example below demonstrates how to use a template to format the email address as a hyperlink by using a template declared in a script block.
 
-The PDF export of the Grid provides the following options and support:  
-* Export of all pages
-* Fit the Grid to the paper size
-* Use page templates
-* Save files by using a server proxy
-* Save files on the server
-* Embed custom fonts and provide Unicode support
+###### Example
 
-For more information on the PDF export of the Grid and its limitations, refer to the article on [exporting of the widget in PDF]({% slug exporting_pdf_kendoui_grid_widget %}).
+    <script id="template" type="text/x-kendo-tmpl">
+        <tr>
+            <td>
+                #= firstName #
+            </td>
+            <td>
+                #= lastName #
+            </td>
+            <td>
+                <a href="mailto:#= email #">#= email #</a>
+            </td>
+        </tr>
+    </script>
 
-## Adaptive Rendering
+Specify this as a template for each row by passing it in to the `rowTemplate` option on the Grid and initializing it with the `kendo.template` function, as demonstrated in the following example.
 
-As of the [Kendo UI Q3 2013 release](http://www.telerik.com/blogs/new-in-kendo-ui-q3-2013), the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
+###### Example
 
-To enable the adaptive rendering feature of the Grid, set the [`mobile`](/api/javascript/ui/grid#configuration-mobile) property to `true`, `phone`, or `tablet`.
+    $("#grid").kendoGrid({
+        rowTemplate: kendo.template($("#template").html()),
+       // other configuration
+    });
 
-When configuring the Grid in terms of responsive web design, it is possible to:
-* Add an adaptive Grid to a Kendo UI mobile application
-* Apply height and positions to parent Grid elements
-* Destroy and adaptive Grid
+In the resulting Grid, the email address is an interactive hyperlink which opens a new email message when clicked.
 
-For more information on the responsive web design of the Grid, refer to the article on the [adaptive rendering of the widget]({% slug adaptive_rendering_kendoui_grid_widget %}).
+**Figure 6. Grid with a row template applied**
 
-## Printing
+![Grid with row template](/controls/data-management/grid/grid8_1.png)
 
-In most cases, the Grid is not the only content on a page. Yet, you might want to print the Grid only.
+For more information on the templating features in Kendo UI, refer to the [introductory article on templates in ASP.NET MVC applications]({% slug overview_kendoui_templatescomponent %}).
 
-To print the content of the Grid only, though the widget might not be the only content on the page, it is possible to use either of the options:
-* Print existing web pages
-* Print new web pages
+### Columns
 
-For more information on printing the Grid, refer to the article on [printing the widget]({% slug printing_kendoui_grid %}).
+Columns need additional specific templating when they represent complex displays and not single fields.
 
-## Localization
+For more information on configuring columns by using templates in the Grid, refer to the article on [binding the Grid to a remote data source]({% slug remote_data_binding_grid %}#set-the-column-template).
 
-The Kendo UI widgets allow you to change the text messages that are displayed to the end user.
+## Other Options
 
-The Grid provides options to localize messages related to the toolbar, columns, filter, grouping, and paging, by setting the following configurations:  
-* `toolbar`
-* `columnMenu`
-* `columns`
-* `filterable`
-* `groupable`
-* `pageable`
+The Grid provides other configuration options as well. The basic ones deliver the possibility to:
 
-For more information on localizing messages in the Grid, refer to the article on [localizing the widget]({% slug localization_kendoui_grid_widget %}).
+* [Edit the Grid]({% slug editing_kendoui_grid_widget %})
+* [Configure its height and width]({% slug appearance_kendoui_grid_widget %}#height)
+* [Configure its columns and rows]({% slug appearance_kendoui_grid_widget %}#columns)
+* [Configure scrolling and virtual scrolling]({% slug appearance_kendoui_grid_widget %}#scrolling)
+* [Initialize it in hidden containers]({% slug appearance_kendoui_grid_widget %}#hidden-containers)
+* [Render it adaptively]({% slug adaptive_rendering_kendoui_grid_widget %})
+* [Localize its messages]({% slug localization_kendoui_grid_widget %})
+* [Export it to Excel]({% slug exporting_excel_kendoui_grid_widget %})
+* [Export it in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Print the Grid]({% slug printing_kendoui_grid %})
 
 ## See Also
 
 * [Grid JavaScript API Reference](/api/javascript/ui/grid)
-* [Editing Functionality]({% slug editing_kendoui_grid_widget %})
-* [Appearance of the Grid]({% slug appearance_kendoui_grid_widget %})
-* [Localization of Messages]({% slug localization_kendoui_grid_widget %})
-* [Adaptive Rendering]({% slug adaptive_rendering_kendoui_grid_widget %})
-* [Export the Grid to Excel]({% slug exporting_excel_kendoui_grid_widget %})
-* [Export the Grid in PDF]({% slug exporting_pdf_kendoui_grid_widget %})
-* [Print the Grid]({% slug exporting_pdf_kendoui_grid_widget %})
+* [Client Detail Templates]({% slug clientdetailtemplate_grid_aspnetmvc %})
+* [Server Detail Templates]({% slug servertemplates_grid_aspnetmvc %})
+* [Editor Templates]({% slug editortemplates_grid_aspnetmvc %})
 
 For how-to examples on the Kendo UI Grid widget, browse its [**How To** documentation folder]({% slug howto_bindto_telerik_backend_services_grid %}).

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -92,6 +92,14 @@ Use either of the two primary approaches to create Kendo UI Grids:
 
 For more information on initializing the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}).
 
+### In Hidden Containers
+
+If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
+
+When you handle the initialization of the Grid in hidden containers, it is possible to use some general as well as specific approaches depending on the particular scenario.
+
+For more information on initializing the Grid inside hidden containers and the approaches to consider, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
+
 ## Data Binding
 
 ### Configure Auto Binding
@@ -441,42 +449,9 @@ The example below demonstrates how to enable the key navigation in the Grid.
 
 For more information on the keyboard navigation of the Grid, refer to the [introductory article of the widget]({% slug overview_kendoui_grid_widget %}#configuration-Keyboard).
 
-## Hidden Containers
+## Export
 
-If a scrollable Grid with a set height is initialized inside a hidden container&mdash;for example, when scrolling, virtual scrolling, or frozen columns are used&mdash;the Grid will not be able to adjust its vertical layout correctly, because the JavaScript calculations of the size do not work for elements of the `display:none` style.
-
-When you handle the initialization of the Grid in hidden containers, it is possible to use some general as well as specific approaches depending on the particular scenario.
-
-For more information on initializing the Grid inside hidden containers and the approaches to consider, refer to the article on the [appearance of the widget]({% slug appearance_kendoui_grid_widget %}#hidden-containers).
-
-## Adaptive Rendering
-
-As of the [Kendo UI Q3 2013 release](http://www.telerik.com/blogs/new-in-kendo-ui-q3-2013), the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
-
-To enable the adaptive rendering feature of the Grid, set the [`mobile`](/api/javascript/ui/grid#configuration-mobile) property to `true`, `phone`, or `tablet`.
-
-When configuring the Grid in terms of responsive web design, it is possible to:
-* Add an adaptive Grid to a Kendo UI mobile application
-* Apply height and positions to parent Grid elements
-* Destroy and adaptive Grid
-
-For more information on the responsive web design of the Grid, refer to the article on the [adaptive rendering of the widget]({% slug adaptive_rendering_kendoui_grid_widget %}).
-
-## Localization
-
-The Kendo UI widgets allow you to change the text messages that are displayed to the end user.
-
-The Grid provides options to localize messages related to the toolbar, columns, filter, grouping, and paging, by setting the following configurations:  
-* `toolbar`
-* `columnMenu`
-* `columns`
-* `filterable`
-* `groupable`
-* `pageable`
-
-For more information on localizing messages in the Grid, refer to the article on [localizing the widget]({% slug localization_kendoui_grid_widget %}).
-
-## Export to Excel
+### Excel
 
 As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in Excel export functionality.
 
@@ -491,7 +466,7 @@ The Excel export of the Grid provides the following options and support:
 
 For more information on the Excel export of the Grid and its limitations, refer to the article on [exporting of the widget to Excel]({% slug exporting_excel_kendoui_grid_widget %}).
 
-## Export to PDF
+### PDF
 
 As of the [Kendo UI Q3 2014 (2014.3.1119) release](http://www.telerik.com/support/whats-new/kendo-ui/release-history/q3-2014), the Grid provides a built-in PDF export functionality.
 
@@ -505,6 +480,19 @@ The PDF export of the Grid provides the following options and support:
 
 For more information on the PDF export of the Grid and its limitations, refer to the article on [exporting of the widget in PDF]({% slug exporting_pdf_kendoui_grid_widget %}).
 
+## Adaptive Rendering
+
+As of the [Kendo UI Q3 2013 release](http://www.telerik.com/blogs/new-in-kendo-ui-q3-2013), the Grid widget supports adaptive enhancements, such as changes in styling and behavior, to provide consistency to the client device experience.
+
+To enable the adaptive rendering feature of the Grid, set the [`mobile`](/api/javascript/ui/grid#configuration-mobile) property to `true`, `phone`, or `tablet`.
+
+When configuring the Grid in terms of responsive web design, it is possible to:
+* Add an adaptive Grid to a Kendo UI mobile application
+* Apply height and positions to parent Grid elements
+* Destroy and adaptive Grid
+
+For more information on the responsive web design of the Grid, refer to the article on the [adaptive rendering of the widget]({% slug adaptive_rendering_kendoui_grid_widget %}).
+
 ## Printing
 
 In most cases, the Grid is not the only content on a page. Yet, you might want to print the Grid only.
@@ -514,6 +502,20 @@ To print the content of the Grid only, though the widget might not be the only c
 * Print new web pages
 
 For more information on printing the Grid, refer to the article on [printing the widget]({% slug printing_kendoui_grid %}).
+
+## Localization
+
+The Kendo UI widgets allow you to change the text messages that are displayed to the end user.
+
+The Grid provides options to localize messages related to the toolbar, columns, filter, grouping, and paging, by setting the following configurations:  
+* `toolbar`
+* `columnMenu`
+* `columns`
+* `filterable`
+* `groupable`
+* `pageable`
+
+For more information on localizing messages in the Grid, refer to the article on [localizing the widget]({% slug localization_kendoui_grid_widget %}).
 
 ## See Also
 

--- a/docs/controls/data-management/grid/walkthrough.md
+++ b/docs/controls/data-management/grid/walkthrough.md
@@ -16,6 +16,7 @@ Use either of the two primary approaches to create Kendo UI Grids:
 
 * From empty `<div>` elements&mdash;in this case all Grid settings are provided in the initialization script statement. This means that you have to describe the layout of the Grid in JavaScript.
 * From HTML tables&mdash;in this case some of the Grid settings can be inferred from the table structure and the HTML attributes of the elements. This means that you can describe the layout of the Grid entirely in the HTML of the table.
+* In hidden containers&mdash;when you initialize a scrollable Grid with a set height in a PanelBar, TabStrip, or Window, you also need to consider some additional layout specifics of the widget.
 
 ### From Empty div Elements
 

--- a/docs/framework/templates/overview.md
+++ b/docs/framework/templates/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # Templates Overview
 
-The [Kendo UI Templates](http://demos.telerik.com/kendo-ui/templates/index) provide a simple-to-use, high-performance JavaScript templating engine within the Kendo UI framework. Templates offer a way to create HTML chunks that can be automatically merged with JavaScript data. They are a substitute for traditional HTML string building in JavaScript.
+The [Kendo UI Templates](http://demos.telerik.com/kendo-ui/templates/index) provide a simple-to-use, high-performance JavaScript templating engine within the Kendo UI toolkit. Templates offer a way to create HTML chunks that can be automatically merged with JavaScript data. They are a substitute for traditional HTML string building in JavaScript.
 
 ## Basics
 
@@ -123,7 +123,7 @@ Then, to consume this external template with an expression, simply initialize a 
             function myCustomFunction (str) {
                 return str.replace(".", " ");
             }
-        
+
             //Get the external template definition using a jQuery selector
             var template = kendo.template($("#javascriptTemplate").html());
 

--- a/docs/updates/2016-doc-updates.md
+++ b/docs/updates/2016-doc-updates.md
@@ -1,30 +1,112 @@
 ---
-title: Kendo UI 2016 Documentation Updates
-page_title: Kendo UI 2016 Documentation Updates | Updates and Contribution
+title: Documentation Updates
+page_title: Documentation Updates | Updates and Contribution
 description: "Learn about the latest updates in Kendo UI documentation released in 2016."
 slug: documentation_updates_2016_kendoui
 position: 1
 ---
 
-# Kendo UI 2016 Documentation Updates
+# Documentation Updates
+
+## August 2016
+
+### Existing
+
+**Conceptual Documentation**
+
+The conceptual documentation on the Grid has gone through a revision. The information related to one and the same feature is now located in one and the same file.
+
+The files that are now changed with regard to their internal structure are:
+
+* **Overview**&mdash;The article handles the topics on initializing the Grid and referencing its existing instance.
+* **Walkthrough**&mdash;The article elaborates on the major features of the Grid, which are data binding, selection, paging, grouping, sorting, keyboard navigation, and templates.
+* **Appearance**&mdash;The article provides a collection of sections on scrolling and virtual scrolling, configuration of the height and width, rows and columns, as well as initialization of the widget in hidden containers such as the PanelBar, TabStrip, and Window.
+
+**How-To Examples**
+
+<table style="width:100%">
+  <col width="40%">
+  <col width="30%">
+  <col width="30%">
+    <tr>
+      <th>Article</th>
+      <th>Previous Location</th>
+      <th>New Location</th>
+    </tr>
+    <tr>
+      <td>Perform CRUD Operations with Local Storage Data</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Editing</strong></td>
+    </tr>
+    <tr>
+      <td>Show Progress for Grid CRUD Operations</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Editing</strong></td>
+    </tr>
+    <tr>
+      <td>Set Cell Color Based on ForeignKey Values</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Appearance</strong></td>
+    </tr>
+    <tr>
+      <td>Show Tooltip for Column Records</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Appearance</strong></td>
+    </tr>
+    <tr>
+      <td>Customize Rows and Cells Based on Data Item Values</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Appearance</strong></td>
+    </tr>
+    <tr>
+      <td>Load and Append More Records While Scrolling Down</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Binding</strong></td>
+    </tr>
+    <tr>
+      <td>Use Nested Model Properties</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Binding</strong></td>
+    </tr>
+    <tr>
+      <td>Use WebAPI with Server-Side Operations</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/Binding</strong></td>
+    </tr>
+    <tr>
+      <td>Persist Expanded Rows after Refresh</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/State Management</strong></td>
+    </tr>
+    <tr>
+      <td>Persist Collapsed State of Grouped Records</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/State Management</strong></td>
+    </tr>
+    <tr>
+      <td>Preserve Grid State in a Cookie</td>
+      <td><strong>../Grid/How To</strong></td>
+      <td><strong>../Grid/How To/State Management</strong></td>
+    </tr>
+</table>
 
 ## May 2016
 
 Below are listed the Kendo UI R2 2016 release changes in the documentation as compared to the Kendo UI Q1 2016 SP1 ones.
 
-### New Files
+### New
 
 The **Copyright** notice is now added.
 
-### Existing Files
+### Existing
 
 **Articles**
 
 <table style="width:100%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
+    <col width="20%">
+    <col width="20%">
+    <col width="30%">
+    <col width="30%">
     <tr>
       <th>Article</th>
       <th>New Name</th>
@@ -35,23 +117,23 @@ The **Copyright** notice is now added.
       <td>Help Improve Kendo UI Documentation</td>
       <td>Contribute to Documentation</td>
       <td><strong>Help Improve Kendo UI Documentation</strong></td>
-      <td><strong>Updates and Contribution</strong> > <strong>Contribute to Kendo UI Documentation</strong></td>
+      <td><strong>Updates and Contribution/Contribute to Kendo UI Documentation</strong></td>
     </tr>
     <tr>
       <td>ASP.NET MVC 3</td>
       <td>Use with ASP.NET MVC 3</td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>ASP.NET MVC Apps</strong></td>
+      <td><strong>UI for ASP.NET MVC/ASP.NET MVC Apps</strong></td>
       <td><strong>UI for ASP.NET MVC</strong></td>
     </tr>
     <tr>
       <td>ASP.NET MVC 4</td>
       <td>Use with ASP.NET MVC 4</td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>ASP.NET MVC Apps</strong></td>
+      <td><strong>UI for ASP.NET MVC/ASP.NET MVC Apps</strong></td>
       <td><strong>UI for ASP.NET MVC</strong></td>
     </tr>
       <td>ASP.NET MVC 5</td>
       <td>Use with ASP.NET MVC 5</td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>ASP.NET MVC Apps</strong></td>
+      <td><strong>UI for ASP.NET MVC/ASP.NET MVC Apps</strong></td>
       <td><strong>UI for ASP.NET MVC</strong></td>
     </tr>
 </table>
@@ -59,10 +141,10 @@ The **Copyright** notice is now added.
 **Folders**
 
 <table style="width:100%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
+    <col width="20%">
+    <col width="20%">
+    <col width="30%">
+    <col width="30%">
     <tr>
       <th>Folders</th>
       <th>New Name</th>
@@ -84,36 +166,36 @@ The **Copyright** notice is now added.
     <tr>
       <td>ASP.NET Core MVC</td>
       <td>Use with ASP.NET Core MVC</td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>ASP.NET MVC Apps</strong></td>
+      <td><strong>UI for ASP.NET MVC/ASP.NET MVC Apps</strong></td>
       <td><strong>UI for ASP.NET MVC</strong></td>
     </tr>
     <tr>
       <td>Tips and Tricks</td>
       <td>Performance Issues</td>
       <td><strong>Styles and Appearance</strong></td>
-      <td><strong>Widgets</strong> > <strong>Charts</strong> > <strong>Troubleshooting</strong></td>
+      <td><strong>../Charts/Troubleshooting</strong></td>
     </tr>
 </table>
 
 ## March 2016
 
-### New Files
+### New
 
-In addition to the renaming and relocation of the above articles, some new ones are now created&mdash;from scratch or as a result of splitting existing ones&mdash;to the purpose of making the documented information more handy.
+In addition to the renaming and relocation of the articles below, some new ones are now created&mdash;from scratch or as a result of splitting existing ones&mdash;to the purpose of making the documented information more handy.
 
 * A new troubleshooting article on Scaffolding when using the Kendo UI Scaffolder Visual Studio Extension is now available. Go to **UI for ASP.NET MVC** > **Troubleshooting** > **Scaffolding** to check it out.
 * A new troubleshooting article on Validation is now available. Go to **UI for ASP.NET MVC** > **Troubleshooting** > **Validation** to check it out.
 * The **Globalization and Localization** article on Telerik UI for ASP.NET MVC is now split to list the two topics separately for a better navigation. The current location of them both is **UI for ASP.NET MVC** > **Globalization** and **UI for ASP.NET MVC** > **Localization** respectively.
 
-### Existing Files
+### Existing
 
 Below are listed the Kendo UI Q1 2016 SP1 (2016.1.226) release changes in the documentation as compared to the Kendo UI Q1 2016 ones.
 
 <table style="width:100%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
-  <col width="25%">
+  <col width="20%">
+  <col width="20%">
+  <col width="30%">
+  <col width="30%">
     <tr>
       <th>Article</th>
       <th>New Name</th>
@@ -123,62 +205,62 @@ Below are listed the Kendo UI Q1 2016 SP1 (2016.1.226) release changes in the do
     <tr>
       <td>Widget wrapper and widget element</td>
       <td>Widget DOM Elements</td>
-      <td><strong>Framework and Utilities</strong> > <strong>Widgets</strong></td>
-      <td><strong>Getting Started</strong> > <strong>Widget Basics</strong></td>
+      <td><strong>Framework and Utilities/Widgets</strong></td>
+      <td><strong>Getting Started/Widget Basics</strong></td>
     </tr>
     <tr>
       <td>Destroy Kendo UI Widgets</td>
       <td>Destroy Widgets</td>
-      <td><strong>Framework and Utilities</strong> > <strong>Widgets</strong></td>
-      <td><strong>Getting Started</strong> > <strong>Widget Basics</strong></td>
+      <td><strong>Framework and Utilities/Widgets</strong></td>
+      <td><strong>Getting Started/Widget Basics</strong></td>
     </tr>
     <tr>
       <td>Create Your Own Kendo UI Widget by Inheriting from the Base Widget Class</td>
       <td>Create Custom Widgets</td>
-      <td><strong>Framework and Utilities</strong> > <strong>Widgets</strong></td>
-      <td><strong>Getting Started</strong> > <strong>Widget Basics</strong></td>
+      <td><strong>Framework and Utilities/Widgets</strong></td>
+      <td><strong>Getting Started/Widget Basics</strong></td>
     </tr>
     <tr>
       <td>Data Attribute Initialization</td>
       <td>Data Attributes</td>
       <td><strong>Framework and Utilities</strong></td>
-      <td><strong>Getting Started</strong> > <strong>Widget Basics</strong></td>
+      <td><strong>Getting Started/Widget Basics</strong></td>
     </tr>
     <tr>
       <td>Class-based Inheritance with Kendo UI</td>
       <td>Class Overview</td>
       <td><strong>Framework and Utilities</strong></td>
-      <td><strong>Framework and Utilities</strong> > <strong>Class</strong></td>
+      <td><strong>Framework and Utilities/Class</strong></td>
     </tr>
     <tr>
       <td>Methods and Events</td>
       <td>Methods and Events</td>
-      <td><strong>Getting Started</strong> > <strong>Widgets</strong></td>
-      <td><strong>Getting Started</strong> > <strong>Widget Basics</strong></td>
+      <td><strong>Getting Started/Widgets</strong></td>
+      <td><strong>Getting Started/Widget Basics</strong></td>
     </tr>
     <tr>
       <td>Troubleshooting</td>
       <td>Common Issues</td>
       <td><strong>UI for ASP.NET MVC</strong></td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>Troubleshooting</strong></td>
+      <td><strong>UI for ASP.NET MVC/Troubleshooting</strong></td>
     </tr>
     <tr>
       <td>Tutorial: Build the Kendo Music Store</td>
       <td>Build the Kendo UI Music Store</td>
       <td><strong>UI for ASP.NET MVC</strong></td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>Tutorials</strong></td>
+      <td><strong>UI for ASP.NET MVC/Tutorials</strong></td>
     </tr>
     <tr>
       <td>Tutorial: Build the Sales Hub Project</td>
       <td>Build the Sales Hub Project</td>
       <td><strong>UI for ASP.NET MVC</strong></td>
-      <td><strong>UI for ASP.NET MVC</strong> > <strong>Tutorials</strong></td>
+      <td><strong>UI for ASP.NET MVC/Tutorials</strong></td>
     </tr>
 </table>
 
 ## January 2016
 
-### Existing Files
+### Existing
 
 Below are listed the Kendo UI Q1 2016 release changes in documentation as compared to the Kendo UI Q3 2015 ones.
 


### PR DESCRIPTION
Latest updates:
* Added new sections to **Walkthrough** which correspond to the conceptual articles.
* Moved related info to one place (the conceptual topics accordingly) leaving short explanations in **Walkthrough**.
* Interlinked the conceptual topics and the **Walkthrough**.
* Created new how-to directories to contextually group the examples and make them easy to find. 
* Fixed language issues, updated headings, and restructured content where necessary.

@dimodi 
* All comments and suggestions on improving the structure of the content and the content itself are much appreciated.  
* It seems a good idea to me to group all how-to examples in directories and make them easier to find. What do you think?
 

 