### PR TITLE
Change Dialog widget close button rendering; include font icon classes

### DIFF
--- a/src/kendo.dialog.js
+++ b/src/kendo.dialog.js
@@ -21,7 +21,7 @@
             NS = "kendoWindow",
             KDIALOG = ".k-dialog",
             KWINDOW = ".k-window",
-            KICONCLOSE = ".k-i-close",
+            KICONCLOSE = ".k-dialog-close",
             KCONTENTCLASS = "k-content",
             KCONTENT = ".k-content",
             KTITLELESS = "k-dialog-titleless",
@@ -747,7 +747,7 @@
             options: {
                 name: "Dialog",
                 messages: {
-                    close: "Close"
+                    close: ""
                 }
             }
         });
@@ -925,7 +925,8 @@
                     "<span class='k-dialog-title'>#= title #</span>" +
                 "</div>"
             ),
-            close: template("<a role='button' href='\\#' class='k-dialog-action k-link' aria-label='Close' tabindex='-1'><span class='k-icon k-i-close'>#= messages.close #</span></a>"),
+            close: template("<a role='button' href='\\#' class='k-button-bare k-dialog-action k-dialog-close' aria-label='Close' tabindex='-1'><span class='k-font-icon k-i-x'>#= messages.close #</span></a>"),
+            // close: template("<a role='button' href='\\#' class='k-dialog-action k-link' aria-label='Close' tabindex='-1'><span class='k-icon k-i-close'>#= messages.close #</span></a>"),
             actionbar: template("<ul class='k-dialog-buttongroup k-dialog-button-layout-#= buttonLayout #' role='toolbar' />"),
             //actionbar: "<ul class='k-dialog-buttongroup k-dialog-button-layout-normal' role='toolbar' />",
             overlay: "<div class='k-overlay' />",

--- a/src/kendo.dialog.js
+++ b/src/kendo.dialog.js
@@ -298,7 +298,12 @@
                 that.appendTo.append(wrapper);
 
                 if (options.closable !== false) {
-                    wrapper.append(templates.close(options));
+                    if (options.title !== false) {
+                        titlebar.append(templates.close(options));
+                    }
+                    else {
+                        wrapper.append(templates.close(options));
+                    }
                 }
 
                 if (options.title !== false) {
@@ -926,9 +931,7 @@
                 "</div>"
             ),
             close: template("<a role='button' href='\\#' class='k-button-bare k-dialog-action k-dialog-close' aria-label='Close' tabindex='-1'><span class='k-font-icon k-i-x'>#= messages.close #</span></a>"),
-            // close: template("<a role='button' href='\\#' class='k-dialog-action k-link' aria-label='Close' tabindex='-1'><span class='k-icon k-i-close'>#= messages.close #</span></a>"),
             actionbar: template("<ul class='k-dialog-buttongroup k-dialog-button-layout-#= buttonLayout #' role='toolbar' />"),
-            //actionbar: "<ul class='k-dialog-buttongroup k-dialog-button-layout-normal' role='toolbar' />",
             overlay: "<div class='k-overlay' />",
             alertWrapper: template("<div class='k-widget k-dialog k-window' role='alertdialog' />"),
             alert: "<div />",

--- a/styles/web/common/core.less
+++ b/styles/web/common/core.less
@@ -16,4 +16,5 @@
 @import "splitter.less";
 @import "virtuallist.less";
 @import "dialog.less";
+@import "font-icons.less";
 @import "../../common/transitions.less";

--- a/styles/web/common/dialog.less
+++ b/styles/web/common/dialog.less
@@ -59,13 +59,17 @@
     padding: 0;
 }
 
-.k-dialog a.k-dialog-action.k-link
+.k-dialog a.k-dialog-action.k-dialog-close
 {
     position: absolute;
     top: 1em;
-    right: 1em;
+    right: .5em;
     cursor: pointer;
     z-index: 10000;
+
+    .k-font-icon {
+        .use-font-icon();
+    }
 }
 
 .k-dialog.k-alert .k-window-titlebar,
@@ -97,3 +101,4 @@
 {
     width: 100%;
 }
+

--- a/styles/web/common/dialog.less
+++ b/styles/web/common/dialog.less
@@ -62,14 +62,19 @@
 .k-dialog a.k-dialog-action.k-dialog-close
 {
     position: absolute;
-    top: 1em;
-    right: .5em;
+    right: 0;
     cursor: pointer;
     z-index: 10000;
 
     .k-font-icon {
         .use-font-icon();
     }
+}
+
+.k-dialog.k-dialog-titleless a.k-dialog-action.k-dialog-close
+{
+    right: .5em;
+    top: 1em;
 }
 
 .k-dialog.k-alert .k-window-titlebar,

--- a/styles/web/kendo.rtl.less
+++ b/styles/web/kendo.rtl.less
@@ -1012,11 +1012,10 @@
 
 .k-rtl .k-dialog, .k-rtl.k-dialog
 {
-    a.k-dialog-action.k-link
+    a.k-dialog-action.k-dialog-close
     {
         position: absolute;
         right: auto;
-        left: 1em;
     }
 
     .k-dialog-buttongroup

--- a/styles/web/type-bootstrap.less
+++ b/styles/web/type-bootstrap.less
@@ -3325,11 +3325,11 @@ td.k-state-focused.k-state-selected,
             font-size: 1.1em;
         }
     }
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         position: absolute;
         padding: 1.1em;
-        right: 0;
-        top: 0.5em;
+        right: .5em;
+        top: .5em;
         line-height: 1em;
         cursor: pointer;
         z-index: 10000;
@@ -3379,7 +3379,7 @@ td.k-state-focused.k-state-selected,
 }
 
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         left: 0.5em;
     }
     .k-dialog-buttongroup {

--- a/styles/web/type-bootstrap.less
+++ b/styles/web/type-bootstrap.less
@@ -3328,11 +3328,15 @@ td.k-state-focused.k-state-selected,
     a.k-dialog-action.k-dialog-close {
         position: absolute;
         padding: 1.1em;
-        right: .5em;
-        top: .5em;
+        right: 0;
+        top: 0;
         line-height: 1em;
         cursor: pointer;
         z-index: 10000;
+    }
+    &.k-dialog-titleless a.k-dialog-action.k-dialog-close {
+        right: 0.5em;
+        top: 0.5em;
     }
     .k-content {
         border-bottom-right-radius: @border-radius;

--- a/styles/web/type-default.less
+++ b/styles/web/type-default.less
@@ -2663,9 +2663,8 @@ textarea.k-textbox,
 }
 
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
-        top: 1em;
-        left: 1em;
+    a.k-dialog-action.k-dialog-close {
+        left: .5em;
     }
     .k-dialog-buttongroup {
         &.k-dialog-button-layout-stretched {

--- a/styles/web/type-flat.less
+++ b/styles/web/type-flat.less
@@ -2677,9 +2677,9 @@ html .km-pane-wrapper .km-widget,
 }
 
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         top: 1em;
-        left: 1em;
+        left: .5em;
     }
     .k-dialog-buttongroup {
         &.k-dialog-button-layout-stretched {

--- a/styles/web/type-highcontrast.less
+++ b/styles/web/type-highcontrast.less
@@ -2548,9 +2548,9 @@ html .km-pane-wrapper .km-widget,
     }
 }
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         top: 1em;
-        left: 1em;
+        left: .5em;
     }
     .k-dialog-buttongroup {
         &.k-dialog-button-layout-stretched {

--- a/styles/web/type-material.less
+++ b/styles/web/type-material.less
@@ -3957,6 +3957,10 @@ div.k-scheduler-marquee:after {
         }
         border-bottom: none;
     }
+    a.k-dialog-action.k-dialog-close {
+        top: .3em;
+        right: 0;
+    }
     .k-dialog-buttongroup {
         .k-button:active,
         .k-button:focus,
@@ -4003,8 +4007,8 @@ div.k-scheduler-marquee:after {
     }
 }
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
-        left: 1em;
+    a.k-dialog-action.k-dialog-close {
+        left: 0;
     }
     .k-dialog-buttongroup {
         &.k-dialog-button-layout-stretched {

--- a/styles/web/type-material.less
+++ b/styles/web/type-material.less
@@ -3942,9 +3942,7 @@ div.k-scheduler-marquee:after {
     }
     .k-window-titlebar {
         border-width: 0;
-        .k-dialog-title {
-            color: @normal-text-color;
-        }
+        color: @normal-text-color;
     }
     .k-header {
         background: none;
@@ -3956,6 +3954,11 @@ div.k-scheduler-marquee:after {
             color: @normal-text-color;
         }
         border-bottom: none;
+    }
+    a.k-dialog-action.k-dialog-close.k-button-bare {
+        &:before {
+            content: normal;
+        }
     }
     a.k-dialog-action.k-dialog-close {
         top: .3em;

--- a/styles/web/type-metro.less
+++ b/styles/web/type-metro.less
@@ -2604,9 +2604,9 @@ html .km-pane-wrapper .km-widget,
     }
 }
 .k-rtl .k-dialog {
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         top: 1em;
-        left: 1em;
+        left: .5em;
     }
     .k-dialog-buttongroup {
         &.k-dialog-button-layout-stretched {

--- a/styles/web/type-nova.less
+++ b/styles/web/type-nova.less
@@ -2129,14 +2129,19 @@ html .km-pane-wrapper .km-widget,
             box-sizing: content-box;
         }
     }
+    a.k-dialog-action.k-dialog-close.k-button-bare {
+        &:before {
+            content: normal;
+        }
+    }
     a.k-dialog-action.k-dialog-close {
-        position: absolute;
         padding: 1em;
         right: 0;
         top: 0;
-        line-height: 1em;
-        cursor: pointer;
-        z-index: 10000;
+    }
+    &.k-dialog-titleless a.k-dialog-action.k-dialog-close {
+        right: 0.5em;
+        top: 0.5em;
     }
     &.k-alert .k-window-titlebar,
     &.k-confirm .k-window-titlebar,

--- a/styles/web/type-nova.less
+++ b/styles/web/type-nova.less
@@ -2129,7 +2129,7 @@ html .km-pane-wrapper .km-widget,
             box-sizing: content-box;
         }
     }
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         position: absolute;
         padding: 1em;
         right: 0;
@@ -2195,7 +2195,7 @@ html .km-pane-wrapper .km-widget,
             padding-left: 2em;
         }
     }
-    a.k-dialog-action.k-link {
+    a.k-dialog-action.k-dialog-close {
         left: 0;
     }
     .k-dialog-buttongroup {

--- a/tests/dialog/api.js
+++ b/tests/dialog/api.js
@@ -180,7 +180,7 @@
             }
         });
 
-        dialog.wrapper.find(".k-i-close").click();
+        dialog.wrapper.find(".k-dialog-close").click();
     });
 
     test("open sets options.visible to true", function() {

--- a/tests/dialog/events.js
+++ b/tests/dialog/events.js
@@ -11,7 +11,7 @@
         }
     });
 
-    var KICONCLOSE = ".k-i-close";
+    var KICONCLOSE = ".k-dialog-close";
 
     function createDialog(options, element) {
         element = element || $("<div class='dialog'>dialog content</div>").appendTo(QUnit.fixture);

--- a/tests/dialog/initialization.js
+++ b/tests/dialog/initialization.js
@@ -32,8 +32,8 @@
         var wrapperChildren = wrapper.children();
 
         ok(wrapper.is(".k-widget.k-dialog.k-window"));
-        ok(wrapperChildren.eq(0).is(".k-dialog-action.k-link"));
-        ok(wrapperChildren.eq(0).children().eq(0).is(".k-icon.k-i-close"));
+        ok(wrapperChildren.eq(0).is(".k-dialog-action.k-dialog-close"));
+        ok(wrapperChildren.eq(0).children().eq(0).is(".k-font-icon.k-i-x"));
         ok(wrapperChildren.eq(1).is(".k-window-titlebar"));
         ok(wrapperChildren.eq(2).is(".k-content"));
         equal(wrapper.find(".k-dialog-buttongroup").length, 0);
@@ -245,7 +245,7 @@
         }).getKendoDialog();
 
         equal(dialog.element.attr("tabindex"), 10);
-        equal(dialog.wrapper.find(".k-i-close").attr("tabindex"), 10);
+        equal(dialog.wrapper.find(".k-dialog-close").attr("tabindex"), 10);
         equal(dialog.wrapper.find(".k-button").attr("tabindex"), 10);
     });
 

--- a/tests/dialog/initialization.js
+++ b/tests/dialog/initialization.js
@@ -32,10 +32,24 @@
         var wrapperChildren = wrapper.children();
 
         ok(wrapper.is(".k-widget.k-dialog.k-window"));
+        ok(wrapperChildren.eq(0).is(".k-window-titlebar"));
+        ok(wrapperChildren.eq(0).children().eq(1).is(".k-dialog-action.k-dialog-close"));
+        ok(wrapperChildren.eq(0).children().eq(1).children().eq(0).is(".k-font-icon.k-i-x"));
+        ok(wrapperChildren.eq(1).is(".k-content"));
+        equal(wrapper.find(".k-dialog-buttongroup").length, 0);
+    });
+
+    test("adds close button to wrapper if titleless", function() {
+        var dialog = createDialog({
+            title: false
+        });
+        var wrapper = dialog.wrapper;
+        var wrapperChildren = wrapper.children();
+
+        ok(wrapper.is(".k-widget.k-dialog.k-window"));
         ok(wrapperChildren.eq(0).is(".k-dialog-action.k-dialog-close"));
         ok(wrapperChildren.eq(0).children().eq(0).is(".k-font-icon.k-i-x"));
-        ok(wrapperChildren.eq(1).is(".k-window-titlebar"));
-        ok(wrapperChildren.eq(2).is(".k-content"));
+        ok(wrapperChildren.eq(1).is(".k-content"));
         equal(wrapper.find(".k-dialog-buttongroup").length, 0);
     });
 


### PR DESCRIPTION
This branch adds the font icon classes from styles/web/common/font-icons.less to styles/web/common/core.less as they were required for the new rendering of the Close button of the Dialog widget (https://github.com/telerik/kendo/issues/6002).

The font icon classes were not added before and I need verification that they will not prove problematic for the rest of the components.