### PR TITLE
Fix ms-clear to hide only for k-input

### DIFF
--- a/styles/web/common/base.less
+++ b/styles/web/common/base.less
@@ -81,7 +81,7 @@
     outline: 0;
 }
 
-.k-widget ::-ms-clear,
+.k-widget .k-input::-ms-clear,
 .k-list-filter ::-ms-clear {
     width : 0;
     height: 0;


### PR DESCRIPTION
The issue is that having a plain, native `<input type="text"/>` in Kendo Window, the ms-clear button under IE is hidden. 

Here you are a dojo: http://dojo.telerik.com/uSEVep.

