### PR TITLE
Apply a breaking change in jQuery 3 for kendo.data #2250

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -2810,7 +2810,10 @@ var __meta__ = { // jshint ignore:line
                     var idx, length;
 
                     for (idx = 0, length = arguments.length; idx < length; idx++){
-                        that._accept(arguments[idx]);
+                        var result = arguments[idx];
+                        if(result) {
+                            that._accept(result);
+                        }
                     }
 
                     that._storeData(true);


### PR DESCRIPTION
In jQuery 1 and 2 the call to $.when with an empty array provides no arguments to the then callback:
$.when().then(function() {
equal(0, arguments.length);
});

In jQuery 3 the then callback has at least one argument.
$.when().then(function() {
equal(1, arguments.length);
});