### PR TITLE
Unbind from change event when removing item

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -81,6 +81,7 @@ var __meta__ = { // jshint ignore:line
 
             Observable.fn.init.call(that);
 
+            that._triggerChangeCallback = $.proxy(that._triggerChange, that);
             that.length = array.length;
 
             that.wrapAll(array, that);
@@ -139,18 +140,21 @@ var __meta__ = { // jshint ignore:line
 
                 object.parent = parent;
 
-                object.bind(CHANGE, function(e) {
-                    that.trigger(CHANGE, {
-                        field: e.field,
-                        node: e.node,
-                        index: e.index,
-                        items: e.items || [this],
-                        action: e.node ? (e.action || "itemloaded") : "itemchange"
-                    });
-                });
+                object.bind(CHANGE, that._triggerChangeCallback);
             }
 
             return object;
+        },
+        
+        _triggerChangeCallback: null,
+        _triggerChange: function (e) {
+            this.trigger(CHANGE, {
+                        field: e.field,
+                        node: e.node,
+                        index: e.index,
+                        items: e.items || [e.sender],
+                        action: e.node ? (e.action || "itemloaded") : "itemchange"
+                    });
         },
 
         push: function() {
@@ -177,8 +181,9 @@ var __meta__ = { // jshint ignore:line
 
         pop: function() {
             var length = this.length, result = pop.apply(this);
-
+            
             if (length) {
+                result.unbind(CHANGE, this._triggerChangeCallback);
                 this.trigger(CHANGE, {
                     action: "remove",
                     index: length - 1,
@@ -203,8 +208,8 @@ var __meta__ = { // jshint ignore:line
                 });
 
                 for (i = 0, len = result.length; i < len; i++) {
-                    if (result[i] && result[i].children) {
-                        result[i].unbind(CHANGE);
+                    if (result[i]) {
+                        result[i].unbind(CHANGE, this._triggerChangeCallback);
                     }
                 }
             }
@@ -223,6 +228,7 @@ var __meta__ = { // jshint ignore:line
             var length = this.length, result = shift.apply(this);
 
             if (length) {
+                result.unbind(CHANGE, this._triggerChangeCallback);
                 this.trigger(CHANGE, {
                     action: "remove",
                     index: 0,


### PR DESCRIPTION
When a Model is being added, a bind to the "change" event from that Model is being set, but when this exactly same item is removed, the unbind it is not being call. This is triggering multiple "change" events when adding and removing the same Model from a collection several times.