### PR TITLE
Fix appended to wrong body

### DIFF
--- a/src/kendo.popup.js
+++ b/src/kendo.popup.js
@@ -84,6 +84,7 @@ var __meta__ = { // jshint ignore:line
             }
 
             parentPopup = $(that.options.anchor).closest(".k-popup,.k-group").filter(":not([class^=km-])"); // When popup is in another popup, make it relative.
+			if(BODY === "body") BODY = document.body;
             options.appendTo = $($(options.appendTo)[0] || parentPopup[0] || BODY);
 
             that.element.hide()

--- a/src/kendo.popup.js
+++ b/src/kendo.popup.js
@@ -84,7 +84,7 @@ var __meta__ = { // jshint ignore:line
             }
 
             parentPopup = $(that.options.anchor).closest(".k-popup,.k-group").filter(":not([class^=km-])"); // When popup is in another popup, make it relative.
-			if(BODY === "body") BODY = document.body;
+            if(BODY === "body") BODY = document.body;
             options.appendTo = $($(options.appendTo)[0] || parentPopup[0] || BODY);
 
             that.element.hide()

--- a/src/kendo.popup.js
+++ b/src/kendo.popup.js
@@ -84,10 +84,8 @@ var __meta__ = { // jshint ignore:line
             }
 
             parentPopup = $(that.options.anchor).closest(".k-popup,.k-group").filter(":not([class^=km-])"); // When popup is in another popup, make it relative.
-            if(BODY === "body") {
-                BODY = document.body;
-            }
-            options.appendTo = $($(options.appendTo)[0] || parentPopup[0] || BODY);
+
+            options.appendTo = $($(options.appendTo)[0] || parentPopup[0] || document.body);
 
             that.element.hide()
                 .addClass("k-popup k-group k-reset")

--- a/src/kendo.popup.js
+++ b/src/kendo.popup.js
@@ -84,7 +84,9 @@ var __meta__ = { // jshint ignore:line
             }
 
             parentPopup = $(that.options.anchor).closest(".k-popup,.k-group").filter(":not([class^=km-])"); // When popup is in another popup, make it relative.
-            if(BODY === "body") BODY = document.body;
+            if(BODY === "body") {
+                BODY = document.body;
+            }
             options.appendTo = $($(options.appendTo)[0] || parentPopup[0] || BODY);
 
             that.element.hide()

--- a/tests/popup/popup.js
+++ b/tests/popup/popup.js
@@ -28,16 +28,15 @@
         equal(div.parent().css("zIndex"), "12");
     });
 
-    asyncTest("mousedown outside the element should close it", function(){
-        div.kendoPopup( {
+    test("mousedown outside the element should close it", 1, function(){
+        popup = new Popup(div, {
             anchor: anchor,
             close: function() {
                 ok(true);
-                start();
             }
-        }).data("kendoPopup").open();
+        });
 
-        popup = div.data("kendoPopup");
+        popup.open();
 
         $(document.documentElement).mousedown();
     });
@@ -842,5 +841,37 @@
         equal(localAnchor[0].getBoundingClientRect().left, div[0].getBoundingClientRect().left);
 
         body.css("margin", defaultMargin);
+    });
+
+    var svgWrapper;
+
+    module("kendo.ui.Popup (multiple bodies)", {
+        setup: function() {
+            kendo.effects.disable();
+            var foreignObjectHtml = '<foreignObject width="100" height="50" requiredExtensions="http://www.w3.org/1999/xhtml"><body xmlns="http://www.w3.org/1999/xhtml"><h1>HTML Foreign Object</h1></body></foreignObject>';
+
+            svgWrapper = $('<svg width="400px" height="300px" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg"></svg>').appendTo(document.body);
+            svgWrapper.append(foreignObjectHtml);
+
+            div = $("<div style='background:red'>popup</div>");
+            anchor = $("<div style='background:blue;position:absolute;left:100px;top:100px;'>anchor</div>").appendTo(QUnit.fixture);
+        },
+        teardown: function() {
+            if (popup) {
+                popup.destroy();
+            }
+
+            div.add(anchor).remove();
+            svgWrapper.remove();
+            kendo.effects.enable();
+        }
+    });
+
+    test("appends to document.body", function() {
+        popup = new Popup(div, { anchor: anchor });
+
+        popup.open();
+
+        equal(div.closest("body")[0], document.body);
     });
 })();


### PR DESCRIPTION
We are facing an issue with the drop-down widget. We found that when an object of type foreignObject with the tag body is present in the page, some unexpected behaviors happens. Reviewing the developer network from Mozilla, the body tag inside foreignObject is valid.

This is already being accepted as an error in Ticket ID:1023316, and in your local bug track as the issue 1559
https://github.com/telerik/kendo-ui-core/issues/1559