### PR TITLE
trigger events on popover open/close

### DIFF
--- a/src/kendo.mobile.popover.js
+++ b/src/kendo.mobile.popover.js
@@ -236,7 +236,8 @@ var __meta__ = { // jshint ignore:line
 
         open: function(target) {
             this.popup.show(target);
-
+            this.trigger('open');
+	    
             if (!this.initialOpen) {
                 if (!this.pane.navigateToInitial()) {
                     this.pane.navigate("");
@@ -255,6 +256,7 @@ var __meta__ = { // jshint ignore:line
         },
 
         close: function() {
+            this.trigger('close');
             this.popup.hide();
         },
 


### PR DESCRIPTION
The open and close events on the mobile popover are not being fired. In the example below, an alert should be shown when the popover closes, but the function is never called.

```
<!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8"/>
    <title>Kendo UI Snippet</title>

    <link rel="stylesheet" href="http://kendo.cdn.telerik.com/2016.3.1028/styles/kendo.common.min.css"/>
    <link rel="stylesheet" href="http://kendo.cdn.telerik.com/2016.3.1028/styles/kendo.rtl.min.css"/>
    <link rel="stylesheet" href="http://kendo.cdn.telerik.com/2016.3.1028/styles/kendo.silver.min.css"/>
    <link rel="stylesheet" href="http://kendo.cdn.telerik.com/2016.3.1028/styles/kendo.mobile.all.min.css"/>

    <script src="http://code.jquery.com/jquery-1.12.4.min.js"></script>
    <script src="http://kendo.cdn.telerik.com/2016.3.1028/js/kendo.all.min.js"></script>
</head>
<body>
  
<div data-role="view" data-show="showPopOver">
  <a id="target" data-role="button" href="#foo" data-rel="popover">Open PopOver</a>

  <div id="foo" data-role="popover">
    <div data-role="view">
      View 1
    </div>
  </div>
</div>

<script>
var app = new kendo.mobile.Application();

function onClose(e) {
  alert("close");
  //handle event
}
var popover;
setTimeout(function(){
  popover = $("#foo").getKendoMobilePopOver();
  popover.bind("close", onClose);
  popover.open($("#target"));
}, 0);
setTimeout(function(){
  popover.close();
  //popover.trigger("close");
}, 2000);
</script>
</body>
</html>
```