### PR TITLE
docs: mark IE8 as unsupported and remove references

### DIFF
--- a/docs/api/javascript/dataviz/diagram/circle.md
+++ b/docs/api/javascript/dataviz/diagram/circle.md
@@ -30,9 +30,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### fill.gradient.center `Array`
 The center of the radial gradient.
 

--- a/docs/api/javascript/dataviz/diagram/path.md
+++ b/docs/api/javascript/dataviz/diagram/path.md
@@ -115,9 +115,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### fill.gradient.center `Array`
 The center of the radial gradient.
 

--- a/docs/api/javascript/dataviz/diagram/polyline.md
+++ b/docs/api/javascript/dataviz/diagram/polyline.md
@@ -93,9 +93,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### fill.gradient.center `Array`
 The center of the radial gradient.
 

--- a/docs/api/javascript/dataviz/diagram/rectangle.md
+++ b/docs/api/javascript/dataviz/diagram/rectangle.md
@@ -30,9 +30,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### fill.gradient.center `Array`
 The center of the radial gradient.
 

--- a/docs/api/javascript/dataviz/diagram/shape.md
+++ b/docs/api/javascript/dataviz/diagram/shape.md
@@ -103,9 +103,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### fill.gradient.center `Array`
 The center of the radial gradient.
 

--- a/docs/api/javascript/dataviz/ui/barcode.md
+++ b/docs/api/javascript/dataviz/ui/barcode.md
@@ -17,7 +17,6 @@ The supported values are:
 
 * "canvas" - renders the widget as a Canvas element, if available.
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 
 #### Example - Render as SVG, if supported
 

--- a/docs/api/javascript/dataviz/ui/chart.md
+++ b/docs/api/javascript/dataviz/ui/chart.md
@@ -9398,7 +9398,6 @@ If it is not supported by the browser, the Chart will switch to the first availa
 The supported values are:
 
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 * "canvas" - renders the widget as a Canvas element, if available.
 
 ### Example - Render as Canvas, if supported

--- a/docs/api/javascript/dataviz/ui/diagram.md
+++ b/docs/api/javascript/dataviz/ui/diagram.md
@@ -2182,9 +2182,6 @@ The type of the gradient. Supported values are:
 * linear
 * radial
 
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
-
 ### shapeDefaults.fill.gradient.center `Array`
 The center of the radial gradient.
 
@@ -2632,9 +2629,6 @@ The type of the gradient. Supported values are:
 
 * linear
 * radial
-
-Note that support for radial gradients in VML (IE8 and below) is limited.
-Not all configurations are guaranteed to work.
 
 ### shapes.fill.gradient.center `Array`
 The center of the radial gradient.

--- a/docs/api/javascript/dataviz/ui/lineargauge.md
+++ b/docs/api/javascript/dataviz/ui/lineargauge.md
@@ -291,7 +291,6 @@ If it is not supported by the browser, the Gauge will switch to the first availa
 The supported values are:
 
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 * "canvas" - renders the widget as a Canvas element, if available.
 
 ### Example - Render as Canvas, if supported

--- a/docs/api/javascript/dataviz/ui/qrcode.md
+++ b/docs/api/javascript/dataviz/ui/qrcode.md
@@ -152,7 +152,6 @@ The supported values are:
 
 * "canvas" - renders the widget as a Canvas element, if available.
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 
 ### size `Number|String`
 

--- a/docs/api/javascript/dataviz/ui/radialgauge.md
+++ b/docs/api/javascript/dataviz/ui/radialgauge.md
@@ -162,7 +162,6 @@ If it is not supported by the browser, the Gauge will switch to the first availa
 The supported values are:
 
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 * "canvas" - renders the widget as a Canvas element, if available.
 
 #### Example - Render as Canvas, if supported

--- a/docs/api/javascript/dataviz/ui/sparkline.md
+++ b/docs/api/javascript/dataviz/ui/sparkline.md
@@ -2186,7 +2186,6 @@ If it is not supported by the browser, the Sparkline will switch to the first av
 The supported values are:
 
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 * "canvas" - renders the widget as a Canvas element, if available.
 
 ### Example - Render as Canvas, if supported

--- a/docs/api/javascript/dataviz/ui/stock-chart.md
+++ b/docs/api/javascript/dataviz/ui/stock-chart.md
@@ -5568,7 +5568,6 @@ If it is not supported by the browser, the Chart will switch to the first availa
 The supported values are:
 
 * "svg" - renders the widget as inline SVG document, if available
-* "vml" - renders the widget as VML, if available
 * "canvas" - renders the widget as a Canvas element, if available.
 
 ### Example - Render as Canvas, if supported

--- a/docs/api/javascript/drawing/element.md
+++ b/docs/api/javascript/drawing/element.md
@@ -19,8 +19,6 @@ The clipping path for this element.
 The path instance will be monitored for changes.
 It can be replaced by calling the [clip](#methods-clip) method.
 
-> The VML surface (IE 8 and earlier) will clip to the path bounding rectangle.
-
 #### Example - setting clipping path on an element
     <div id="surface"></div>
     <script>
@@ -42,7 +40,7 @@ It can be replaced by calling the [clip](#methods-clip) method.
 ### cursor `String`
 The element [CSS cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor).
 
-Applicable to SVG and VML outputs.
+Applicable to SVG output.
 
 #### Example - set hand cursor on an element
     <div id="surface"></div>
@@ -87,8 +85,6 @@ Returns the bounding box of the element with transformations applied.
 
 ### clip
 Gets or sets the element clipping path.
-
-> The VML surface (IE 8 and earlier) will clip to the path bounding rectangle.
 
 #### Example - setting clipping path on an element
     <div id="surface"></div>

--- a/docs/api/javascript/drawing/element.md
+++ b/docs/api/javascript/drawing/element.md
@@ -40,7 +40,7 @@ It can be replaced by calling the [clip](#methods-clip) method.
 ### cursor `String`
 The element [CSS cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor).
 
-Applicable to SVG output.
+Applicable to an SVG output.
 
 #### Example - set hand cursor on an element
     <div id="surface"></div>

--- a/docs/api/javascript/drawing/radial-gradient.md
+++ b/docs/api/javascript/drawing/radial-gradient.md
@@ -6,9 +6,6 @@ page_title: API reference for Kendo UI Drawing API RadialGradient
 # kendo.drawing.RadialGradient : kendo.drawing.Gradient
 Represents a radial color gradient.
 
-Note that support for radial gradients in VML is limited.
-Not all configurations are guaranteed to work.
-
 #### Example - creating a radial gradient
     <div id="surface" />
     <script>

--- a/docs/api/javascript/drawing/surface.md
+++ b/docs/api/javascript/drawing/surface.md
@@ -8,7 +8,7 @@ An abstract class representing the top-level drawing surface.
 This class can't be instantiated directly.
 
 Specific implementations are created via the static `create` method.
-The implementations for SVG, Canvas and VML inherit from this base class.
+The implementations for SVG and Canvas inherit from this base class.
 
 ## Example - Creating a drawing surface
     <div id="container" style="position: relative; width: 600px; height: 400px;"></div>
@@ -63,7 +63,6 @@ The preferred type of surface to [create](#create).
 Supported types (case insensitive):
 - `svg`
 - `canvas`
-- `vml`
 
 This option will be ignored if not supported by the browser.
 See [Supported Browsers](/intro/supporting/browser-support).

--- a/docs/api/javascript/ui/editor.md
+++ b/docs/api/javascript/ui/editor.md
@@ -1875,7 +1875,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari. PDF export is not supported in Internet Explorer 8 and below.
+A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/editor.md
+++ b/docs/api/javascript/ui/editor.md
@@ -1875,7 +1875,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
+A proxy will be used when the browser is not capable of saving files locally, for example, Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -5897,7 +5897,7 @@ A scale factor.  In many cases, text size on screen will be too big for print, s
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari. PDF export is not supported in Internet Explorer 8 and below.
+A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -5897,7 +5897,7 @@ A scale factor.  In many cases, text size on screen will be too big for print, s
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
+A proxy will be used when the browser is not capable of saving files locally, for example, Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/pivotgrid.md
+++ b/docs/api/javascript/ui/pivotgrid.md
@@ -635,7 +635,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari. PDF export is not supported in Internet Explorer 8 and below.
+A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/pivotgrid.md
+++ b/docs/api/javascript/ui/pivotgrid.md
@@ -241,7 +241,6 @@ If set to true, the content will be forwarded to [proxyURL](#configuration-excel
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally.
 Such browsers are IE version 9 and lower and Safari.
 
 The developer is responsible for implementing the server-side proxy.
@@ -635,7 +634,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
+A proxy will be used when the browser is not capable of saving files locally, for example, Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/progressbar.md
+++ b/docs/api/javascript/ui/progressbar.md
@@ -149,8 +149,6 @@ Specifies if the progress status will be shown.
 
 Specifies the type of the **ProgressBar**. The supported types are **value**, **percent** and **chunk**.
 
-> **Important** The **chunk** progress type is not supported in Internet Explorer 7.
-
 #### Example - set the type of the ProgressBar
 
 	<div id="progressbar"></div>

--- a/docs/api/javascript/ui/spreadsheet.md
+++ b/docs/api/javascript/ui/spreadsheet.md
@@ -519,7 +519,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
+A proxy will be used when the browser is not capable of saving files locally, for example, Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/api/javascript/ui/spreadsheet.md
+++ b/docs/api/javascript/ui/spreadsheet.md
@@ -519,7 +519,7 @@ Supported values:
 
 The URL of the server side proxy which will stream the file to the end user.
 
-A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari. PDF export is not supported in Internet Explorer 8 and below.
+A proxy will be used when the browser isn't capable of saving files locally e.g. Internet Explorer 9 and Safari.
 
 The developer is responsible for implementing the server-side proxy.
 

--- a/docs/controls/barcodes/barcode/overview.md
+++ b/docs/controls/barcodes/barcode/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # Barcode Overview
 
-The [Kendo UI Barcode widget](http://demos.telerik.com/kendo-ui/barcode/index) is used to represent data in a machine-readable format. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](http://www.w3.org/Graphics/SVG/) with a fallback to [Vector Markup Language (VML)](https://en.wikipedia.org/wiki/Vector_Markup_Language) for legacy browsers.
+The [Kendo UI Barcode widget](http://demos.telerik.com/kendo-ui/barcode/index) is used to represent data in a machine-readable format. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](http://www.w3.org/Graphics/SVG/).
 
 ## Getting Started
 

--- a/docs/controls/barcodes/qrcode/overview.md
+++ b/docs/controls/barcodes/qrcode/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # QRCode Overview
 
-The [Kendo UI QRCode widget](http://demos.telerik.com/kendo-ui/qrcode/index) helps you easily generate [Canvas](https://en.wikipedia.org/wiki/Canvas_X) and [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) images representing QR codes. QR is short for Quick Response, intended to signify that they can be read quickly by a cell phone. [QR codes](https://en.wikipedia.org/wiki/QR_code) are used to take a piece of information from a transitory media and put it in to your cell phone. All graphics are rendered on the client by using Canvas or SVG with a fallback to [Vector Markup Language (VML)](https://en.wikipedia.org/wiki/Vector_Markup_Language) for legacy browsers.
+The [Kendo UI QRCode widget](http://demos.telerik.com/kendo-ui/qrcode/index) helps you easily generate [Canvas](https://en.wikipedia.org/wiki/Canvas_X) and [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) images representing QR codes. QR is short for Quick Response, intended to signify that they can be read quickly by a cell phone. [QR codes](https://en.wikipedia.org/wiki/QR_code) are used to take a piece of information from a transitory media and put it in to your cell phone. All graphics are rendered on the client by using Canvas or SVG.
 
 ## Getting Started
 

--- a/docs/controls/barcodes/qrcode/overview.md
+++ b/docs/controls/barcodes/qrcode/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # QRCode Overview
 
-The [Kendo UI QRCode widget](http://demos.telerik.com/kendo-ui/qrcode/index) helps you easily generate [Canvas](https://en.wikipedia.org/wiki/Canvas_X) and [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) images representing QR codes. QR is short for Quick Response, intended to signify that they can be read quickly by a cell phone. [QR codes](https://en.wikipedia.org/wiki/QR_code) are used to take a piece of information from a transitory media and put it in to your cell phone. All graphics are rendered on the client by using Canvas or SVG.
+The [Kendo UI QRCode widget](http://demos.telerik.com/kendo-ui/qrcode/index) helps you easily generate [Canvas](https://en.wikipedia.org/wiki/Canvas_X) and [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) images representing QR codes. QR is short for Quick Response, intended to signify that they can be read quickly by a cell phone. [QR codes](https://en.wikipedia.org/wiki/QR_code) are used to take a piece of information from a transitory media and put it into your cell phone. All graphics are rendered on the client by using Canvas or SVG.
 
 ## Getting Started
 

--- a/docs/controls/charts/export.md
+++ b/docs/controls/charts/export.md
@@ -367,7 +367,6 @@ Below are listed the most important ones for you to note:
 
 * The maximum document size is limited to 5080x5080mm (200x200 inches) by the PDF 1.5 specification. Larger files might not open in all viewers.
 * Older browsers, such as Internet Explorer 9 and Safari, require the implementation of a server proxy. For more information on this, refer to [the `proxyUrl` configuration section](/api/javascript/ui/grid#configuration-pdf.proxyURL).
-* PDF export is not supported in Internet Explorer 8 and older.
 
 ## Further Reading
 

--- a/docs/controls/charts/overview.md
+++ b/docs/controls/charts/overview.md
@@ -9,7 +9,7 @@ position: 1
 
 # Chart Overview
 
-The [Kendo UI Charts](http://demos.telerik.com/kendo-ui/) use modern browser technologies to render high-quality data visualizations. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) with a fallback to [Canvas](http://www.canvasgfx.com/) and [Vector Markup Language (VML)](https://en.wikipedia.org/wiki/Vector_Markup_Language).
+The [Kendo UI Charts](http://demos.telerik.com/kendo-ui/) use modern browser technologies to render high-quality data visualizations. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) with a fallback to [Canvas](http://www.canvasgfx.com/).
 
 Kendo UI Charts support the following series types:
 

--- a/docs/controls/data-management/grid/pdf-export.md
+++ b/docs/controls/data-management/grid/pdf-export.md
@@ -378,7 +378,6 @@ Note that even with the proper CORS headers, IE9 will not be able to load images
 
 * The maximum document size is limited to 5080x5080mm (200x200 inches) by the PDF 1.5 specification. Larger files might not open in all viewers.
 * Older browsers, such as Internet Explorer 9 and Safari, require the implementation of a server proxy. For more information on this, refer to [the `proxyUrl` configuration section](/api/javascript/ui/grid#configuration-pdf.proxyURL).
-* PDF export is not supported in Internet Explorer 8 and older.
 
 ## Further Reading
 

--- a/docs/controls/data-management/pivotgrid/export.md
+++ b/docs/controls/data-management/pivotgrid/export.md
@@ -16,7 +16,6 @@ PDF export is enabled by default when `kendo.all.min.js`, `kendo.web.min.js`, or
 
 > **Important**  
 > * Exporting in older browsers, such as Internet Explorer 9 and older, or Safari, requires the implementation of a server proxy. For more information, see the [`proxyUrl` configuration sections above](/api/javascript/ui/pivotgrid#configuration-pdf).
-> * PDF export is not supported in Internet Explorer 8 and older browser versions.
 
 ## Excel Export
 

--- a/docs/controls/gauges/lineargauge/overview.md
+++ b/docs/controls/gauges/lineargauge/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # Linear Gauge Overview
 
-The [Kendo UI Linear Gauge widget](http://demos.telerik.com/kendo-ui/linear-gauge/index) is used to let users quickly understand where a value lies in a certain range. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) with a fallback to [Vector Markup Language (VML)](https://en.wikipedia.org/wiki/Vector_Markup_Language) for legacy browsers.
+The [Kendo UI Linear Gauge widget](http://demos.telerik.com/kendo-ui/linear-gauge/index) is used to let users quickly understand where a value lies in a certain range. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics).
 
 ## Getting Started
 

--- a/docs/controls/gauges/radialgauge/overview.md
+++ b/docs/controls/gauges/radialgauge/overview.md
@@ -8,7 +8,7 @@ position: 1
 
 # Radial Gauge Overview
 
-The [Kendo UI Radial Gauge widget](http://demos.telerik.com/kendo-ui/radial-gauge/index) is used to let users quickly understand where a value lies in a certain range. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) with a fallback to [Vector Markup Language (VML)](https://en.wikipedia.org/wiki/Vector_Markup_Language) for legacy browsers.
+The [Kendo UI Radial Gauge widget](http://demos.telerik.com/kendo-ui/radial-gauge/index) is used to let users quickly understand where a value lies in a certain range. All graphics are rendered on the client using [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics).
 
 ## Getting Started
 

--- a/docs/controls/layout/responsivepanel/overview.md
+++ b/docs/controls/layout/responsivepanel/overview.md
@@ -12,7 +12,7 @@ The [Kendo UI ResponsivePanel widget](http://demos.telerik.com/kendo-ui/responsi
 
 > **Important**  
 >
-> CSS3 media queries are supported in Internet Explorer 9 and later versions. This means that Kendo UI ResponsivePanel does not support Internet Explorer 7 and Internet Explorer 8.
+> CSS3 media queries are supported in Internet Explorer 9 and later versions.
 
 ## Configuration
 

--- a/docs/framework/drawing/basic-shapes.md
+++ b/docs/framework/drawing/basic-shapes.md
@@ -205,7 +205,7 @@ The [`Surface.create`](/api/javascript/drawing/surface#create) method, as demons
             surface.draw(group);
         </script>
 
-The default output is an SVG with fallback to Canvas.
+The default output is an SVG with a fallback to Canvas.
 
 ## See Also
 

--- a/docs/framework/drawing/basic-shapes.md
+++ b/docs/framework/drawing/basic-shapes.md
@@ -205,7 +205,7 @@ The [`Surface.create`](/api/javascript/drawing/surface#create) method, as demons
             surface.draw(group);
         </script>
 
-The default output is an SVG with fallback to Canvas or VML.
+The default output is an SVG with fallback to Canvas.
 
 ## See Also
 

--- a/docs/framework/drawing/drawing-dom.md
+++ b/docs/framework/drawing/drawing-dom.md
@@ -12,7 +12,7 @@ The [Kendo UI Drawing API](http://demos.telerik.com/kendo-ui/drawing/index) supp
 
 ## Getting Started
 
-Using the `drawing.drawDOM` function you can draw a DOM element into a [`drawing.Group`](/api/dataviz/drawing/group), which you are then able to render with one of the supported backends into SVG, PDF, HTML5 `<canvas>`, or VML format.
+Using the `drawing.drawDOM` function you can draw a DOM element into a [`drawing.Group`](/api/dataviz/drawing/group), which you are then able to render with one of the supported backends into SVG, PDF or HTML5 `<canvas>` format.
 
 The DOM element must be appended to the document and fully rendered, meaning that you cannot draw an element which has the `display: none`, or the `visibility: hidden` options. Assume that you have the following HTML in the page:
 

--- a/docs/framework/drawing/drawing-dom.md
+++ b/docs/framework/drawing/drawing-dom.md
@@ -12,7 +12,7 @@ The [Kendo UI Drawing API](http://demos.telerik.com/kendo-ui/drawing/index) supp
 
 ## Getting Started
 
-Using the `drawing.drawDOM` function you can draw a DOM element into a [`drawing.Group`](/api/dataviz/drawing/group), which you are then able to render with one of the supported backends into SVG, PDF or HTML5 `<canvas>` format.
+Using the `drawing.drawDOM` function you can draw a DOM element into a [`drawing.Group`](/api/dataviz/drawing/group), which you are then able to render with one of the supported backends into SVG, PDF, or HTML5 `<canvas>` format.
 
 The DOM element must be appended to the document and fully rendered, meaning that you cannot draw an element which has the `display: none`, or the `visibility: hidden` options. Assume that you have the following HTML in the page:
 

--- a/docs/framework/drawing/supported-browsers.md
+++ b/docs/framework/drawing/supported-browsers.md
@@ -18,7 +18,6 @@ Surfaces are listed in their order of preference. You can request a specific [`t
 | ---     | ---  | ---   | ---     | ---    | --- | ---
 | SVG     | 9+   | ✓     | ✓       | ✓      | ✓   | 4+
 | Canvas  | 10+  | ✓     | ✓       | ✓      | ✓   | ✓
-| VML     | 7+   | ✕     | ✕       | ✕      | ✕   | ✕
 
 ## PDF Export
 

--- a/docs/intro/supporting/browser-support.md
+++ b/docs/intro/supporting/browser-support.md
@@ -20,7 +20,7 @@ Most [Kendo UI widgets]({% slug bundle_supportfor_kendoui_components %}) have no
 | BROWSER           | SUPPORTED VERSIONS            | LIMITATIONS
 | :---------------- | :---------------------------- | :---------------
 | Edge              | 20 or later ([officially supported versions by Microsoft only](https://en.wikipedia.org/wiki/Microsoft_Edge#Release_history)) |
-| Internet Explorer | 8 or later                    | Kendo UI [Spreadsheet](http://demos.telerik.com/kendo-ui/spreadsheet/index) and [Responsive panel](http://demos.telerik.com/kendo-ui/responsive-panel/index) require IE9 or later
+| Internet Explorer | 9 or later                    |
 | Chrome            | Current and previous          |
 | Firefox           | [Current and ESR releases](https://en.wikipedia.org/wiki/History_of_Firefox#Release_history) ([What is ESR?](https://www.mozilla.org/en-US/firefox/organizations/faq/))|
 | Opera             | 15 or later                   |
@@ -58,9 +58,6 @@ The [hybrid UI widgets and frameworks]({% slug bundle_supportfor_kendoui_compone
 
 | BROWSER           | SUPPORTED VERSIONS            | LIMITATIONS                               |
 | :---------------- | :---------------------------- | :-----------                              |
-| Internet Explorer | 8                             | PDF and image export is not supported     |
-|                   |                               | Text rotation is not supported by the 64-bit versions |
-|                   |                               | Gradients in pie and donut charts are not supported |
 | Internet Explorer | 10                            | Dashed lines in canvas are not supported, which affects the image export as well |
 |                   |                               | Android 2.x, therefore, uses non-interactive canvas output |
 | Android           | 2.3                           | The Canvas rendering mode is only supported
@@ -74,7 +71,6 @@ The Kendo UI PDF generator is tested and supported in the following _desktop_ br
 
 Officially, PDF export is not supported on mobile because of browser limitations and CORS-related security restrictions in hybrid applications. For example, it is not possible to load locally stored font files in hybrid applications. Though exporting in PDF might work on some mobile devices in specific scenarios, PDF export is _not_ supported in:
 
-* Internet Explorer 8 and older
 * Mobile browsers
 * Hybrid mobile applications
 
@@ -88,6 +84,7 @@ To ensure the best performance of your project, make sure that you:
 
 ### Notes on Web Browser Support
 
+* As of the Kendo UI 2017 R1 release, Internet Explorer 8 is no longer supported.
 * As of the Kendo UI 2015 Q3 release, Internet Explorer 7 is no longer supported.
 * Since Internet Explorer 11 was released in October 2013, look up the Kendo UI 2013 Q3 SP2 (2013.3.1324) release or a more recent Kendo UI version if you need support for it.
 * Browsers in beta stage are not supported.

--- a/docs/styles-and-layout/appearance-styling.md
+++ b/docs/styles-and-layout/appearance-styling.md
@@ -88,7 +88,7 @@ The example below demonstrates how to take advantage of these classes.
 ###### Example
 
     .k-ie { /* styles to be applied to all versions of Internet Explorer */ }
-    .k-ie7 { /* styles to be applied to IE7 only */ }
+    .k-ie9 { /* styles to be applied to IE9 only */ }
     .k-ff { /* styles to be applied to all versions of Firefox */ }
 
 <!--*-->

--- a/docs/styles-and-layout/rendering.md
+++ b/docs/styles-and-layout/rendering.md
@@ -12,12 +12,11 @@ position: 4
 The [Kendo UI Gauges, Charts, Barcodes, Diagrams, and Maps](http://demos.telerik.com/kendo-ui/) widgets support the following rendering targets:
 
 * SVG
-* VML
 * Canvas
 
 ## Mode Selection
 
-The rendering mode is automatically chosen based on availability. The order is SVG > VML > Canvas for all widgets rendering data visualization except for the Barcode and QRCode. These components do not require interactivity and default to Canvas rendering. You can set the preferred rendering mode in the [`renderAs`](/api/dataviz/chart#configuration-renderAs) option.
+The rendering mode is automatically chosen based on availability. The order is SVG > Canvas for all widgets rendering data visualization except for the Barcode and QRCode. These components do not require interactivity and default to Canvas rendering. You can set the preferred rendering mode in the [`renderAs`](/api/dataviz/chart#configuration-renderAs) option.
 
 The example below demonstrates how to configure the preferred rendering mode to Canvas by using the `renderAs` option.
 
@@ -39,7 +38,6 @@ The example below demonstrates how to configure the preferred rendering mode to 
 The rendering modules are available as separate files:
 
 * `kendo.dataviz.svg(.min).js`
-* `kendo.dataviz.vml(.min).js`
 * `kendo.dataviz.canvas(.min).js`
 
 You must include at least one, the rest are optional.
@@ -57,11 +55,6 @@ Some rendering modes impose limitations on the available features. Below is a sh
 ### SVG
 
 * None
-
-### VML
-
-* Gradient overlays are not supported for Kendo UI Donut Charts.
-* Reduced performance, especially in Internet Explorer 8 version.
 
 ### Canvas
 

--- a/docs/styles-and-layout/themebuilder.md
+++ b/docs/styles-and-layout/themebuilder.md
@@ -18,7 +18,7 @@ The [Kendo UI ThemeBuilder](http://demos.telerik.com/kendo-ui/themebuilder/web.h
 After adjusting the theme via the ThemeBuilder, click **Download theme**. This provides the following files:
 
 * `kendo.custom.css`&mdash;This is the custom theme for most widgets. You are able to use this theme instead of any `kendo.[theme].css` one.
-* `kendo.custom.json`&mdash;The custom theme for charting widgets, the ones that use `SVG`/`VML`/`Canvas` rendering. Use the contents of this file to [create a custom Chart theme]({% slug howto_customizechartthemes_charts %}) and then set a custom theme name via the [`theme` configuration option](/api/javascript/dataviz/ui/chart#configuration-theme).
+* `kendo.custom.json`&mdash;The custom theme for charting widgets, the ones that use `SVG`/`Canvas` rendering. Use the contents of this file to [create a custom Chart theme]({% slug howto_customizechartthemes_charts %}) and then set a custom theme name via the [`theme` configuration option](/api/javascript/dataviz/ui/chart#configuration-theme).
 * `kendo.custom.less`&mdash;The [LESS](http://lesscss.org/) that includes the custom theme. Use this file if you want to compile the theme dynamically.
 
 > **Important**

--- a/docs/third-party/tutorials/webforms/asp-net-hello-html5.md
+++ b/docs/third-party/tutorials/webforms/asp-net-hello-html5.md
@@ -46,7 +46,7 @@ The JavaScript Application Programming Interface (API) is one of the most import
 
 ### Browser Support
 
-HTML5 is entirely dependent on the browser in which the application is running, which usually is not within the capacity of developers to control. This is more difficult for ASP.NET developers who usually target the Internet Explorer (IE). Older IE versions, such as IE 7 or 8, are terribly fragmented, and their support for HTML5 is not good enough. IE 9 and later versions feature a significant improvement in this direction.
+HTML5 is entirely dependent on the browser in which the application is running, which usually is not within the capacity of developers to control. This is more difficult for ASP.NET developers who usually target the Internet Explorer (IE). IE 9 and later versions feature a significant improvement in this direction.
 
 HTML5 has more to do with the browser technology rather than with ASP.NET. ASP.NET is as capable as any other platform of producing HTML5 applications. Due to the enterprise adoption of the entire Microsoft stack (Windows, Office, Active Directory, and IE), however, ASP.NET developers are sometimes limited in their ability to move their web applications forward into the HTML5 space.
 


### PR DESCRIPTION
Marked IE8 as unsupported and removed obsolete parts of the documentation.

Closes #2004
