### PR TITLE
Update class name to .k-minus

### DIFF
--- a/docs/controls/data-management/grid/how-to/state/persist-expanded-rows.md
+++ b/docs/controls/data-management/grid/how-to/state/persist-expanded-rows.md
@@ -21,7 +21,7 @@ The example below demonstrates how to persist expanded rows after refresh in a K
         $(document).ready(function() {
           $("#refresh").click(function() {
                 var grid = $("#grid").data("kendoGrid");
-                var expanded = $.map(grid.tbody.children(":has(> .k-hierarchy-cell .k-i-collapse)"), function (row) {
+                var expanded = $.map(grid.tbody.children(":has(> .k-hierarchy-cell .k-minus)"), function (row) {
                     return $(row).data("uid");
                 });
 


### PR DESCRIPTION
The documentation example does not work with the latest version of Kendo UI. The "collapse" class for an expanded row in a grid is now '.k-minus' instead of '.k-i-collapse'