### PR TITLE
chore: rename .k-button-bare to .k-button.k-bare

### DIFF
--- a/src/kendo.colorpicker.js
+++ b/src/kendo.colorpicker.js
@@ -600,12 +600,12 @@ var __meta__ = { // jshint ignore:line
                     '# } #' +
                     '#= !data.input ? \'style=\"visibility: hidden;\"\' : \"\" #>' +
                 '# if (clearButton && !_standalone) { #' +
-                    '<span class="k-clear-color k-button-bare" title="#: messages.clearColor #"></span>' +
+                    '<span class="k-clear-color k-button k-bare" title="#: messages.clearColor #"></span>' +
                 '# } #' +
                 '</div></div></div>' +
             '# } #' +
              '# if (clearButton && !_standalone && !preview) { #' +
-                    '<div class="k-clear-color-container"><span class="k-clear-color k-button-bare">#: messages.clearColor #</span></div>' +
+                    '<div class="k-clear-color-container"><span class="k-clear-color k-button k-bare">#: messages.clearColor #</span></div>' +
              '# } #' +
             '<div class="k-hsv-rectangle"><div class="k-hsv-gradient"></div><div class="k-draghandle"></div></div>' +
             '<input class="k-hue-slider" />' +

--- a/src/kendo.dialog.js
+++ b/src/kendo.dialog.js
@@ -950,7 +950,7 @@
                     "<div class='k-window-actions k-dialog-actions' />" +
                 "</div>"
             ),
-            close: template("<a role='button' href='\\#' class='k-button-bare k-window-action k-dialog-action k-dialog-close' title='#= messages.close #' aria-label='#= messages.close #' tabindex='-1'><span class='k-icon k-i-close'></span></a>"),
+            close: template("<a role='button' href='\\#' class='k-button k-bare k-window-action k-dialog-action k-dialog-close' title='#= messages.close #' aria-label='#= messages.close #' tabindex='-1'><span class='k-icon k-i-close'></span></a>"),
             actionbar: template("<div class='k-button-group k-dialog-buttongroup k-dialog-button-layout-#= buttonLayout #' role='toolbar' />"),
             overlay: "<div class='k-overlay' />",
             alertWrapper: template("<div class='k-widget k-window k-dialog' role='alertdialog' />"),

--- a/src/kendo.tabstrip.js
+++ b/src/kendo.tabstrip.js
@@ -162,7 +162,7 @@ var __meta__ = { // jshint ignore:line
     }
 
     function scrollButtonHtml(buttonClass, iconClass) {
-        return "<span class='k-button k-button-icon k-button-bare k-tabstrip-" + buttonClass + "' unselectable='on'><span class='k-icon " + iconClass + "'></span></span>";
+        return "<span class='k-button k-button-icon k-bare k-tabstrip-" + buttonClass + "' unselectable='on'><span class='k-icon " + iconClass + "'></span></span>";
     }
 
     var TabStrip = Widget.extend({

--- a/styles/web/common/base.less
+++ b/styles/web/common/base.less
@@ -96,8 +96,7 @@
 
 /* button */
 
-.k-button,
-.k-button-bare
+.k-button
 {
     display: inline-block;
     margin: 0;
@@ -115,20 +114,12 @@
 .k-state-disabled .k-button:hover,
 .k-button.k-state-disabled:hover,
 .k-state-disabled .k-button:active,
-.k-button.k-state-disabled:active,
-.k-button-bare[disabled],
-.k-button-bare.k-state-disabled,
-.k-state-disabled .k-button-bare,
-.k-state-disabled .k-button-bare:hover,
-.k-button-bare.k-state-disabled:hover,
-.k-state-disabled .k-button-bare:active,
-.k-button-bare.k-state-disabled:active
+.k-button.k-state-disabled:active
 {
     cursor: default;
 }
 
-a.k-button,
-a.k-button-bare
+a.k-button
 {
     .prohibit-selection;
     text-decoration: none;
@@ -141,9 +132,7 @@ a.k-button-bare
 }
 
 button.k-button::-moz-focus-inner,
-input.k-button::-moz-focus-inner,
-.button.k-button-bare::-moz-focus-inner,
-input.k-button-bare::-moz-focus-inner
+input.k-button::-moz-focus-inner
 {
     padding: 0;
     border: 0;
@@ -195,15 +184,14 @@ body .k-split-button-arrow
     vertical-align: text-top;
 }
 
-html body .k-button-bare
-{
-    background: none !important; /*spares long selectors*/
+// Bare button
+.k-button.k-bare {
+    border-color: transparent !important;
     color: inherit;
-    border-width: 0;
-    opacity: 0.7;
-    box-shadow: none;
+    background: none !important;
+    box-shadow: none !important;
+    opacity: .7;
 
-    &,
     &:hover,
     &.k-state-hover,
     &:active,
@@ -214,10 +202,7 @@ html body .k-button-bare
 
     &:focus,
     .k-state-focused {
-        background: none;
-        box-shadow: none !important;
-        border-color: transparent;
-        opacity: 0.8;
+        opacity: .8;
     }
 
     &:hover,
@@ -226,11 +211,21 @@ html body .k-button-bare
     &.k-state-active {
         opacity: 1;
     }
-}
 
-html body .k-button-bare.k-upload-button:hover
-{
-    color: inherit;
+    // Icon
+    .k-icon,
+    .k-font-icon {
+        overflow: visible;
+    }
+
+    &:focus,
+    .k-state-focused {
+        .k-icon,
+        .k-font-icon {
+            text-shadow: 0 0 3px currentColor;
+        }
+    }
+
 }
 
 /* link */
@@ -372,18 +367,6 @@ html body .k-button-bare.k-upload-button:hover
         & when (@icon-positioning = "material") {
             .sprite-position(@row, @column);
         }
-    }
-}
-
-.k-button-bare .k-icon,
-.k-button-bare .k-font-icon {
-    overflow: visible;
-}
-
-.k-button-bare {
-    &.k-state-focused .k-font-icon,
-    &:focus .k-font-icon {
-        text-shadow: 0 0 3px currentColor;
     }
 }
 
@@ -656,7 +639,6 @@ html .k-error-colored
 }
 
 .k-button,
-.k-button-bare,
 .k-textbox,
 .k-autocomplete,
 div.k-window-content,
@@ -682,8 +664,7 @@ div.k-window-content,
     padding: 0;
 }
 
-a.k-button:hover,
-a.k-button-bare:hover
+a.k-button:hover
 {
     text-decoration: none;
 }

--- a/styles/web/type-bootstrap.less
+++ b/styles/web/type-bootstrap.less
@@ -727,7 +727,7 @@ html .km-pane-wrapper .k-header
     border-color: @focused-border-color;
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {

--- a/styles/web/type-default.less
+++ b/styles/web/type-default.less
@@ -723,11 +723,11 @@ html .km-pane-wrapper .k-header
     background-color: transparent;
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {
-    color: @accent;
+        color: @accent;
     }
 }
 

--- a/styles/web/type-flat.less
+++ b/styles/web/type-flat.less
@@ -729,7 +729,7 @@ html .km-pane-wrapper .k-header
     border-color: @focused-border-color;
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {

--- a/styles/web/type-highcontrast.less
+++ b/styles/web/type-highcontrast.less
@@ -718,7 +718,7 @@ html .km-pane-wrapper .k-header
     border-color: @focused-border-color;
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {

--- a/styles/web/type-material.less
+++ b/styles/web/type-material.less
@@ -725,27 +725,33 @@ html .km-pane-wrapper .k-header
     border-color: @focused-border-color;
 }
 
-.k-button-bare {
+.k-button.k-bare {
+    position: relative;
+
+    &:before {
+        content: "";
+        background-color: currentcolor;
+        opacity: 0.12;
+        border-radius: inherit;
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: -1;
+        display: none;
+    }
+
     &.k-state-focused,
     &:focus {
-        position: relative;
 
         &:before {
-            content: "";
-            background-color: currentcolor;
-            opacity: 0.12;
-            border-radius: inherit;
-            height: 100%;
-            width: 100%;
-            position: absolute;
-            left: 0;
-            top: 0;
-            z-index: -1;
+            display: block;
         }
     }
 }
 
-.k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {
@@ -3981,7 +3987,7 @@ div.k-scheduler-marquee:after {
         }
         border-bottom: none;
     }
-    a.k-dialog-action.k-dialog-close.k-button-bare {
+    a.k-dialog-action.k-dialog-close.k-button.k-bare {
         &:before {
             content: normal;
         }

--- a/styles/web/type-metro.less
+++ b/styles/web/type-metro.less
@@ -664,7 +664,7 @@ html .km-pane-wrapper .k-header
     color: @button-hover-text-color;
 }
 
-.k-tabstrip-scrollable .k-button-bare:hover {
+.k-tabstrip-scrollable .k-button.k-bare:hover {
     background: @button-hover-background-color !important;
 }
 
@@ -713,7 +713,7 @@ html .km-pane-wrapper .k-header
     background-color: transparent;
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {

--- a/styles/web/type-nova.less
+++ b/styles/web/type-nova.less
@@ -394,26 +394,32 @@ textarea.k-textbox:hover,
 }
 
 /* Bare Button */
-html body .k-button-bare {
+.k-button.k-bare {
+    position: relative;
+
+    &:before {
+        content: "";
+        background-color: currentcolor;
+        opacity: 0.12;
+        border-radius: inherit;
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        display: none;
+    }
+
     &.k-state-focused,
     &:focus {
-        position: relative;
 
         &:before {
-            content: "";
-            background-color: currentcolor;
-            opacity: 0.12;
-            border-radius: inherit;
-            height: 100%;
-            width: 100%;
-            position: absolute;
-            left: 0;
-            top: 0;
+            display: block;
         }
     }
 }
 
-html .k-mediaplayer-toolbar .k-button-bare {
+.k-mediaplayer-toolbar .k-button.k-bare {
     &:active,
     &.k-state-active,
     &.k-state-active:hover {
@@ -2246,7 +2252,7 @@ html .km-pane-wrapper .km-widget,
             box-sizing: content-box;
         }
     }
-    a.k-dialog-action.k-dialog-close.k-button-bare {
+    a.k-dialog-action.k-dialog-close.k-button.k-bare {
         &:before {
             content: normal;
         }

--- a/tests/dialog/api.js
+++ b/tests/dialog/api.js
@@ -186,12 +186,12 @@
     test("closing dialog from close handler prevents link default behavior", 1, function() {
         var dialog = createDialog();
         var closeElemenet = dialog.wrapper.find(".k-dialog-close");
-        closeElemenet.on("click", function(e){ 
-            ok(e.isDefaultPrevented()); 
+        closeElemenet.on("click", function(e){
+            ok(e.isDefaultPrevented());
         });
 
         closeElemenet.click();
-    });    
+    });
 
     test("open sets options.visible to true", function() {
         var dialog = createDialog({ visible: false });
@@ -278,7 +278,7 @@
             }]
         });
 
-        dialog.wrapper.find(".k-button").click();
+        dialog.wrapper.find(".k-dialog-buttongroup .k-button").click();
         ok(!dialog.options.visible);
         ok(!dialog.wrapper.is(":visible"));
     });
@@ -293,7 +293,7 @@
             }]
         });
 
-        dialog.wrapper.find(".k-button").click();
+        dialog.wrapper.find(".k-dialog-buttongroup .k-button").click();
         ok(dialog.options.visible);
         ok(dialog.wrapper.is(":visible"));
     });

--- a/tests/tabstrip/scrolling.js
+++ b/tests/tabstrip/scrolling.js
@@ -114,7 +114,7 @@ test('scrolling CSS class is not applied to TabStrip if not needed and tabPositi
 test('scrolling buttons are rendered if tabs do not fit', 3, function () {
     createTabStrip();
 
-    var buttons = tabstrip.wrapper.children(".k-button.k-button-icon.k-button-bare");
+    var buttons = tabstrip.wrapper.children(".k-button.k-button-icon.k-bare");
 
     equal(buttons.length, 2);
     ok(buttons.eq(0).is(".k-tabstrip-prev"));
@@ -124,7 +124,7 @@ test('scrolling buttons are rendered if tabs do not fit', 3, function () {
 test('scrolling buttons are not rendered if tabs fit', 1, function () {
     createNonScrollableTabStrip();
 
-    var buttons = tabstrip.wrapper.children(".k-button.k-button-icon.k-button-bare");
+    var buttons = tabstrip.wrapper.children(".k-button.k-button-icon.k-bare");
 
     equal(buttons.length, 0);
 });
@@ -135,7 +135,7 @@ test('right scrolling button scrolls to the right by delta when clicked', 1, fun
     tabstrip.tabGroup.scrollLeft(0);
     tabstrip.wrapper.children(".k-tabstrip-next").trigger("mousedown").trigger("mouseup");
     tabstrip.tabGroup.finish();
-    
+
     equal(tabstrip.tabGroup.scrollLeft(), tabstrip.options.scrollable.distance);
 });
 


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-default/pull/188

The question is whether or not to use the same consistent styling of bare button in all skins? Currently not all skins have the faded background on hover / focus / active. If you examine nova / material you will see what I mean.