### PR TITLE
chore(window): use .k-button.k-bare for window actions

### DIFF
--- a/src/kendo.dialog.js
+++ b/src/kendo.dialog.js
@@ -950,7 +950,7 @@
                     "<div class='k-window-actions k-dialog-actions' />" +
                 "</div>"
             ),
-            close: template("<a role='button' href='\\#' class='k-button k-bare k-window-action k-dialog-action k-dialog-close' title='#= messages.close #' aria-label='#= messages.close #' tabindex='-1'><span class='k-icon k-i-close'></span></a>"),
+            close: template("<a role='button' href='\\#' class='k-button k-bare k-button-icon k-window-action k-dialog-action k-dialog-close' title='#= messages.close #' aria-label='#= messages.close #' tabindex='-1'><span class='k-icon k-i-close'></span></a>"),
             actionbar: template("<div class='k-button-group k-dialog-buttongroup k-dialog-button-layout-#= buttonLayout #' role='toolbar' />"),
             overlay: "<div class='k-overlay' />",
             alertWrapper: template("<div class='k-widget k-window k-dialog' role='alertdialog' />"),

--- a/src/kendo.window.js
+++ b/src/kendo.window.js
@@ -464,7 +464,7 @@
                 if (e.target != e.currentTarget || that._closing) {
                     return;
                 }
-                
+
 
                 if (options.draggable && !e.ctrlKey && !isMaximized) {
                     offset = kendo.getOffset(wrapper);
@@ -1282,11 +1282,11 @@
                 wrapper = contentHtml = null;
             }
         });
-        
+
         templates = {
             wrapper: template("<div class='k-widget k-window' />"),
             action: template(
-                "<a role='button' href='\\#' class='k-window-action k-link' aria-label='#= name #'>" +
+                "<a role='button' href='\\#' class='k-button k-bare k-button-icon k-window-action' aria-label='#= name #'>" +
                 "<span class='k-icon k-i-#= name.toLowerCase() #'></span>" +
                 "</a>"
             ),

--- a/styles/web/common/window.less
+++ b/styles/web/common/window.less
@@ -86,21 +86,9 @@ div.k-window-iframecontent
 
 .k-window-titlebar .k-window-action
 {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
+    width: 22px; // 16 (icon) + 2 * 2 (padding) + 2 * 1 (border)
+    height: 22px;
     padding: 2px;
-    text-decoration: none;
-    vertical-align: middle;
-    opacity: .7;
-}
-
-.k-window-titlebar .k-state-hover
-{
-    border-style: solid;
-    border-width: 1px;
-    padding: 1px;
-    opacity: 1;
 }
 
 .k-window-action .k-icon


### PR DESCRIPTION
It's worth nothing that switching to bare button in window, removes the hover effect for some skins, especially those without the notion of bare button.

/cc @yordanov @lkarakoleva 