### PR TITLE
fix(Window): Dialog loses modality when opened after closing a Window

### DIFF
--- a/src/kendo.window.js
+++ b/src/kendo.window.js
@@ -585,7 +585,7 @@
                 var content = element.children(KWINDOWCONTENT);
                 var widget = kendo.widgetInstance(content);
 
-                if (widget instanceof Window) {
+                if (widget) {
                     return widget;
                 }
 

--- a/tests/dialog/api.js
+++ b/tests/dialog/api.js
@@ -4,8 +4,8 @@
             //
         },
         teardown: function() {
-            QUnit.fixture.closest("body").find(".dialog").each(function(idx, element) {
-                $(element).data("kendoDialog").destroy();
+            QUnit.fixture.closest("body").find(".k-window-content").each(function(idx, element) {
+                kendo.widgetInstance($(element)).destroy();
             });
             QUnit.fixture.closest("body").find(".k-overlay").remove();
         }
@@ -18,6 +18,10 @@
     function createDialog(options, element) {
         element = element || $("<div class='dialog'>dialog content</div>").appendTo(QUnit.fixture);
         return element.kendoDialog(options).data("kendoDialog");
+    }
+
+    function createWindow(options) {
+        return $("<div />").appendTo(QUnit.fixture).kendoWindow(options).data("kendoWindow");
     }
 
     test("title gets title", function() {
@@ -162,6 +166,16 @@
 
     test("closing dialog moves overlay before previous modal dialog", function() {
         var dialog1 = createDialog();
+        var dialog2 = createDialog();
+
+        dialog2.close();
+
+        equal($(".k-overlay").length, 1);
+        ok(dialog1.wrapper.prev("div").is(".k-overlay"));
+    });
+
+    test("closing dialog moves overlay before previous modal dialog", function() {
+        var dialog1 = createWindow({modal: true});
         var dialog2 = createDialog();
 
         dialog2.close();

--- a/tests/window/api.js
+++ b/tests/window/api.js
@@ -7,7 +7,7 @@
         },
         teardown: function() {
             QUnit.fixture.closest("body").find(".k-window-content").each(function(idx, element){
-                $(element).data("kendoWindow").destroy();
+                 kendo.widgetInstance($(element)).destroy();
             });
             QUnit.fixture.closest("body").find(".k-overlay").remove();
             $.mockjax.clear();
@@ -17,6 +17,10 @@
 
     function createWindow(options) {
         return $("<div />").appendTo(QUnit.fixture).kendoWindow(options).data("kendoWindow");
+    }
+
+    function createDialog(options) {
+        return $("<div />").appendTo(QUnit.fixture).kendoDialog(options).data("kendoDialog");
     }
 
     test("title gets title", function() {
@@ -140,6 +144,18 @@
 
     test("closing a modal window moves overlay before previous window", function() {
         var dialog = createWindow({
+                modal: true
+            }),
+            overlappingDialog = createWindow({
+                modal: true
+            });
+
+        overlappingDialog.close();
+        ok(dialog.wrapper.prev("div").is(".k-overlay"));
+    });
+
+    test("closing a modal window moves overlay before previous Kendo Dialog too", function() {
+        var dialog = createDialog({
                 modal: true
             }),
             overlappingDialog = createWindow({


### PR DESCRIPTION
Related to: #2889 telerik/kendo-ui-core#2889