### PR TITLE
fix(numericTextBox): enhance accessibility telerik/kendo#6786

### DIFF
--- a/src/kendo.numerictextbox.js
+++ b/src/kendo.numerictextbox.js
@@ -42,6 +42,7 @@ var __meta__ = { // jshint ignore:line
         ARIA_DISABLED = "aria-disabled",
         INTEGER_REGEXP = /^(-)?(\d*)$/,
         NULL = null,
+        EMPTY_NUMERIC = "Empty numeric",
         proxy = $.proxy,
         extend = $.extend;
 
@@ -55,8 +56,7 @@ var __meta__ = { // jshint ignore:line
 
              options = that.options;
              element = that.element
-                           .on("focusout" + ns, proxy(that._focusout, that))
-                           .attr("role", "spinbutton");
+                           .on("focusout" + ns, proxy(that._focusout, that));
 
              options.placeholder = options.placeholder || element.attr("placeholder");
 
@@ -100,8 +100,12 @@ var __meta__ = { // jshint ignore:line
                  });
              }
 
-             element.attr("aria-valuemin", options.min !== NULL ? options.min*options.factor : options.min)
-                    .attr("aria-valuemax", options.max !== NULL ? options.max*options.factor : options.max);
+             element.attr({
+                 "title": that._initialTitle || options.value || EMPTY_NUMERIC,
+                 "role": "spinbutton",
+                 "aria-valuemin": options.min !== NULL ? options.min*options.factor : options.min,
+                 "aria-valuemax": options.max !== NULL ? options.max*options.factor : options.max
+             });
 
              options.format = extractFormat(options.format);
 
@@ -715,7 +719,7 @@ var __meta__ = { // jshint ignore:line
                 input.val(this.options.placeholder);
             }
 
-            input.attr("title", this._initialTitle || input.val());
+            input.attr("title", this._initialTitle || input.val() || EMPTY_NUMERIC);
         },
 
         _wrapper: function() {

--- a/tests/textbox/aria.js
+++ b/tests/textbox/aria.js
@@ -1,6 +1,7 @@
 (function() {
     var NumericTextBox = kendo.ui.NumericTextBox,
-        input;
+        input,
+        EMPTY_NUMERIC = "Empty numeric";
 
     module("kendo.ui.NumericTextBox ARIA", {
         setup: function() {
@@ -58,6 +59,27 @@
         equal(input.attr("aria-valuenow"), "10");
     });
 
+    test("NumericTextBox adds title when value is empty", function() {
+        var numeric = new NumericTextBox(input);
+
+        equal(input.attr("title"), EMPTY_NUMERIC);
+    });
+
+    test("NumericTextBox adds title when value is set", function() {
+        var numeric = new NumericTextBox(input, {
+            value: 10
+        });
+
+        equal(input.attr("title"), "10");
+    });
+
+    test("NumericTextBox adds title when title attr is set.", function() {
+        var testTitle = "test title";
+        var numeric = new NumericTextBox(input.attr("title", testTitle));
+
+        equal(input.attr("title"), testTitle);
+    });
+
     test("NumericTextBox adds role to the text element", function() {
         var numeric = new NumericTextBox(input);
 
@@ -106,5 +128,26 @@
         });
 
         equal(numeric._text.attr("aria-valuenow"), undefined);
+    });
+
+    test("NumericTextBox adds title when value is empty", function() {
+        var numeric = new NumericTextBox(input);
+
+        equal(numeric._text.attr("title"), EMPTY_NUMERIC);
+    });
+
+    test("NumericTextBox adds title when value is set", function() {
+        var numeric = new NumericTextBox(input, {
+            value: 10
+        });
+
+        equal(numeric._text.attr("title"), "10.00");
+    });
+
+    test("NumericTextBox adds title when title attr is set.", function() {
+        var testTitle = "test title";
+        var numeric = new NumericTextBox(input.attr("title", testTitle));
+
+        equal(numeric._text.attr("title"), testTitle);
     });
 })();


### PR DESCRIPTION
Add empty default title when attribute is missing to enhance the accessibility of numeric text box.

Related to:  telerik/kendo#6786