### PR TITLE
fix(numeric): visual feedback remove on focusout 

### DIFF
--- a/src/kendo.numerictextbox.js
+++ b/src/kendo.numerictextbox.js
@@ -414,6 +414,7 @@ var __meta__ = { // jshint ignore:line
             clearTimeout(that._focusing);
             that._inputWrapper.removeClass(FOCUSED).removeClass(HOVER);
             that._blur();
+            that._removeInvalidState();
         },
 
         _format: function(format, culture) {

--- a/tests/textbox/validation.js
+++ b/tests/textbox/validation.js
@@ -37,4 +37,15 @@
         ok(!textbox._inputWrapper.hasClass(STATE_INVALID));
         equal(textbox._validationIcon.css("display"), "none");
     });
+
+
+    test("hidden invalid decoration on focusout.", function () {
+        var textbox = input.kendoNumericTextBox().data("kendoNumericTextBox");
+        textbox.element
+            .trigger(keyPressA)
+            .focusout();
+
+        ok(!textbox._inputWrapper.hasClass(STATE_INVALID));
+        equal(textbox._validationIcon.css("display"), "none");
+    });
 })();


### PR DESCRIPTION
Bug steps to reproduce:
1. Type invalid character in first input.
2. While the button with invalid character is pressed, click inside other input
Result: The error state of first input will remain, independently if the value of the input is valid.

Related to: telerik/kendo#6759