### PR TITLE
docs(calendar): message for accessibility telerik/kendo#6783

### DIFF
--- a/docs/api/javascript/ui/calendar.md
+++ b/docs/api/javascript/ui/calendar.md
@@ -169,6 +169,38 @@ note that a check for an empty `date` is needed, as the widget can work with a n
         });
     </script>
 
+### messages `Object`
+
+Allows localization of the strings that are used in the widget.
+
+#### Example
+
+    <div id="calendar"></div>
+    <script>
+    $("#calendar").kendoCalendar({
+        "weekNumber": true,
+        "messages": {
+            "weekColumnHeader": "W"
+        }
+     })
+    </script>
+
+### messages.weekColumnHeader `String` *(default: "")*
+
+Allows customization of the week column header text. Set the value to make the widget compliant with web accessibility standards.
+
+#### Example
+
+    <div id="calendar"></div>
+    <script>
+    $("#calendar").kendoCalendar({
+        "weekNumber": true,
+        "messages": {
+            "weekColumnHeader": "W"
+        }
+     })
+    </script>
+
 ### min `Date`*(default: Date(1900, 0, 1))*
 
  Specifies the minimum date, which the calendar can show.


### PR DESCRIPTION
In order to make the Kendo UI Calendar Widget accessible we need to allow user to set value in the empty <th> cell above week column.

See also: 
* [Demo](http://dojo.telerik.com/eGOfA)
* Issue: telerik/kendo#6783