### PR TITLE
fix(panelbar): expand toggles children's collapse icons

### DIFF
--- a/src/kendo.panelbar.js
+++ b/src/kendo.panelbar.js
@@ -1508,7 +1508,7 @@ var __meta__ = { // jshint ignore:line
                 .attr(ARIA_EXPANDED, !visibility)
                 .attr(ARIA_HIDDEN, visibility)
                 .toggleClass(ACTIVECLASS, !visibility)
-                .find("> .k-link > .k-panelbar-collapse, .k-panelbar-expand")
+                .find("> .k-link > .k-panelbar-collapse,> .k-link > .k-panelbar-expand")
                     .toggleClass("k-i-arrow-n", !visibility)
                     .toggleClass("k-panelbar-collapse", !visibility)
                     .toggleClass("k-i-arrow-s", visibility)

--- a/tests/panelbar/api.js
+++ b/tests/panelbar/api.js
@@ -205,6 +205,13 @@
         equal(item.find('> .k-group').css("display"), "none");
     });
 
+    test('expand method should toggle only one icon', function() {
+        new PanelBar(empty_panelbar, { dataSource: [ { text: "Item 1", items: [{ text: "Child 1", items: [{text:"SubChild"}] }] } ] });
+        empty_panelbar.data("kendoPanelBar").expand(empty_panelbar.find("li:first"));
+
+        equal(empty_panelbar.find(".k-panelbar-collapse").length, 1);
+    });
+
     test('dataSource should create items with the text specified', function () {
         new PanelBar(empty_panelbar, { dataSource: [ { text: "Item 1" } ] });
 


### PR DESCRIPTION
Related to: telerik/kendo-ui-core#2964