### PR TITLE
Remove misleading code snippets from Scroller API reference

### DIFF
--- a/docs/api/javascript/mobile/ui/scroller.md
+++ b/docs/api/javascript/mobile/ui/scroller.md
@@ -39,17 +39,13 @@ Has effect only when the `pullToRefresh` option is set to `true`.
 #### Example
     <div data-role="view">
         foo
-        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "pullTemplate": "Go" }'>
+        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "pullTemplate": "Go!" }'>
             <div style="height: 500px">
                 Content
             </div>
         </div>
         bar
     </div>
-
-    <script id="go" type="text/x-kendo-template">
-        Go!
-    </script>
 
     <script>
     new kendo.mobile.Application();
@@ -63,17 +59,13 @@ Has effect only when the `pullToRefresh` option is set to `true`.
 #### Example
     <div data-role="view">
         foo
-        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "refreshTemplate": "progress" }'>
+        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "refreshTemplate": "In progress..." }'>
             <div style="height: 500px">
                 Content
             </div>
         </div>
         bar
     </div>
-
-    <script id="progress" type="text/x-kendo-template">
-        In progress...
-    </script>
 
     <script>
     new kendo.mobile.Application();
@@ -87,17 +79,13 @@ Has effect only when the `pullToRefresh` option is set to `true`.
 #### Example
     <div data-role="view">
         foo
-        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "releaseTemplate": "release" }'>
+        <div data-role="scroller" style="width: 200px; height: 200px" data-pull-to-refresh="true" data-messages='{ "releaseTemplate": "Let it go now..." }'>
             <div style="height: 500px">
                 Content
             </div>
         </div>
         bar
     </div>
-
-    <script id="progress" type="text/x-kendo-template">
-        Let it go now...
-    </script>
 
     <script>
     new kendo.mobile.Application();


### PR DESCRIPTION
The Scroller messages can only be strings. The templates specified in the code snippets are actually ignored and the strings specified as template IDs are directly used as messages.