### PR TITLE
fix(dropdownlist): item overflow when server filtering is enabled

### DIFF
--- a/src/kendo.list.js
+++ b/src/kendo.list.js
@@ -663,11 +663,7 @@ var __meta__ = { // jshint ignore:line
             siblings.each(function() {
                 var element = $(this);
 
-                if (element.hasClass("k-list-filter")) {
-                    offsetHeight += outerHeight(element.children());
-                } else {
-                    offsetHeight += outerHeight(element);
-                }
+                offsetHeight += outerHeight(element);
             });
 
             return offsetHeight;


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-theme-default/issues/406