### PR TITLE
fix(dialog): wrong content height when custom height is set

### DIFF
--- a/styles/web/common/base.less
+++ b/styles/web/common/base.less
@@ -639,7 +639,8 @@ html .k-error-colored
 .k-widget *:before,
 .k-animation-container *:after,
 .k-block .k-header,
-.k-list-container
+.k-list-container,
+div.k-window-content
 {
     .box-sizing(content-box);
 }
@@ -647,7 +648,6 @@ html .k-error-colored
 .k-button,
 .k-textbox,
 .k-autocomplete,
-div.k-window-content,
 .k-tabstrip > .k-content > .km-scroll-container,
 .k-block,
 .k-edit-cell .k-widget,


### PR DESCRIPTION
related https://github.com/telerik/kendo-theme-default/issues/426