### PR TITLE
Reconfigure the es-US culture

### DIFF
--- a/src/cultures/kendo.culture.es-US.js
+++ b/src/cultures/kendo.culture.es-US.js
@@ -6,13 +6,13 @@
             decimals: 2,
             ",": ",",
             ".": ".",
-            groupSize: [3,0],
+            groupSize: [3],
             percent: {
                 pattern: ["-n%","n%"],
                 decimals: 2,
                 ",": ",",
                 ".": ".",
-                groupSize: [3,0],
+                groupSize: [3],
                 symbol: "%"
             },
             currency: {


### PR DESCRIPTION
Changing the groupSize configuration to correctly format numbers according to the es-US culture (ex: 500 will now be formatted as "500.00" instead of ",500.00")