### PR TITLE
docs: Fix numbered lists formatting in how-to articles

### DIFF
--- a/docs/controls/data-management/grid/how-to/Layout/auto-resize-grid-when-hiding-and-showing-columns.md
+++ b/docs/controls/data-management/grid/how-to/Layout/auto-resize-grid-when-hiding-and-showing-columns.md
@@ -12,6 +12,7 @@ Your project might require you to resize the Grid to match the visible column wi
 This approach prevents the appearance of white space in the widget when the sum of the widths of the visible columns is less than the initial width of the Grid.
 
 To achieve this behavior:
+
 1. Store the initial width of the Grid in a variable.
 2. To call the method that performs the necessary calculations, use the [`dataBound`](http://docs.telerik.com/kendo-ui/api/javascript/ui/grid#events-dataBound), [`columnShow`](http://docs.telerik.com/kendo-ui/api/javascript/ui/grid#events-columnShow), and [`columnHide`](http://docs.telerik.com/kendo-ui/api/javascript/ui/grid#events-columnHide) events.
 

--- a/docs/controls/data-management/grid/how-to/binding/load-and-append-records.md
+++ b/docs/controls/data-management/grid/how-to/binding/load-and-append-records.md
@@ -13,6 +13,7 @@ The following example demonstrates how to load more records when scrolling the G
 The difference between this scenario and virtual scrolling is that here the number of records constantly increases, while virtual scrolling replaces the existing records with new ones. Note that when you increase the page size, the data requests are slower.
 
 To achieve this behavior:
+
 1. Subscribe to the `scroll` event of the Grid data container and increment the page size by a desired value.
 2. Use a flag to prevent multiple simultaneous page size increments. The flag should be set in the `scroll` event handler, and cleared in the `dataBound` event handler of the Grid.
 

--- a/docs/controls/data-management/grid/how-to/filtering/grid-with-excel-like-filter.md
+++ b/docs/controls/data-management/grid/how-to/filtering/grid-with-excel-like-filter.md
@@ -12,6 +12,7 @@ The following example demonstrates how to set the Grid with an Excel-like filter
 To set a single Data Source for all filter menus, the example uses the [`columns.filterable.dataSource`](/api/javascript/ui/grid#configuration-columns.filterable.dataSource) property of the Grid.
 
 To observe this behavior:
+
 1. Filter the **Product Name** column.
 2. Open the **Unit Price** column. Note that the values are filtered based on the currently applied filter on the **Product Name** column.
 

--- a/docs/controls/data-management/grid/how-to/filtering/use-custom-validation-in-filter-menus.md
+++ b/docs/controls/data-management/grid/how-to/filtering/use-custom-validation-in-filter-menus.md
@@ -12,6 +12,7 @@ Your project might require you to validate the user input in the filtering user 
 For example, by using the Kendo UI DatePicker for date fields or the Kendo UI NumericTextBox for numeric fields.
 
 To achieve this behavior:
+
 1. Handle the [`filterMenuInit`](/api/javascript/ui/grid#events-filterMenuInit) event and get a reference to the corresponding widgets.
 2. Get a reference to the built-in Kendo UI Validator.
 3. Use the [`rules`](/api/javascript/ui/validator#configuration-rules) and [`messages`](/api/javascript/ui/validator#configuration-messages) options of the Validator to add the necessary custom validation logic and messages.

--- a/docs/controls/diagrams-and-maps/diagram/how-to/modify-undo-redo-stack.md
+++ b/docs/controls/diagrams-and-maps/diagram/how-to/modify-undo-redo-stack.md
@@ -10,6 +10,7 @@ slug: howto_modify_undoredo_stack
 The following example demonstrates how to add custom actions to the undo-redo stack of the Diagram to cover custom interactions such as changing the color of the shape.
 
 To achieve this behavior:
+
 1. Handle the event that triggers the change. For example, the `click` event of the button in this how-to example.
 2. Declare a custom `Unit` class by using the `init`, `undo`, and `redo` methods.
 3. Create an instance of this class.

--- a/docs/controls/diagrams-and-maps/diagram/how-to/move-shapes-on-key-press.md
+++ b/docs/controls/diagrams-and-maps/diagram/how-to/move-shapes-on-key-press.md
@@ -10,6 +10,7 @@ slug: howto_move_shapes_with_arrow_keys
 Your project might require you to move the shapes of the Diagram by pressing the arrow keys.
 
 To achieve this behavior:
+
 1. Handle the `load` event of the Diagram and check whether the selected item is a shape.
 2. If the clicked object is a shape, assign a handler to the standard `keyPress` event of the `window` object.
 3. To move the shape depending on the pressed key, use the `bounds()` method of the `Shape`.

--- a/docs/controls/diagrams-and-maps/diagram/how-to/pan-with-mouse-wheel.md
+++ b/docs/controls/diagrams-and-maps/diagram/how-to/pan-with-mouse-wheel.md
@@ -10,6 +10,7 @@ slug: howto_pan_with_mouse_wheel
 The following example demonstrates how to pan the Kendo UI Diagram when scrolling with the mouse.
 
 To achieve this behavior:
+
 1. Handle the [`zoomStart` event](/api/javascript/dataviz/ui/diagram#events-zoomStart) of the Kendo UI Diagram.
 2. Get the delta from the arguments, that is `e.meta.delta`.
 3. Pan the Diagram with the new coordinates by using the [`pan` method](/api/javascript/dataviz/ui/diagram#methods-pan).

--- a/docs/controls/diagrams-and-maps/diagram/how-to/show-context-menu-over-shapes.md
+++ b/docs/controls/diagrams-and-maps/diagram/how-to/show-context-menu-over-shapes.md
@@ -10,6 +10,7 @@ slug: howto_show_context_menu_over_shapes
 The following example demonstrates how to show a Kendo UI ContextMenu when pressing the right button of the mouse over the Diagram shapes.
 
 To achieve this behavior:
+
 1. Initialize a [Kendo UI ContextMenu]({% slug overview_kendoui_contextmenu_widget %}) setting its target as the ID of the Diagram and filter it by a `g` element.
 2. Handle the [`open` event](/api/javascript/ui/contextmenu#events-open) of the ContextMenu. If the target is a connection, it is possible to cancel the event. If the target is a shape, it is possible to store the `dataItem` in a variable.
 3. Handle the [`select` event](/api/javascript/ui/contextmenu#events-select) of the ContextMenu where you can perform a custom action based on the context of the shape.

--- a/docs/controls/interactivity/draganddrop/how-to/disable-dragging-runtime.md
+++ b/docs/controls/interactivity/draganddrop/how-to/disable-dragging-runtime.md
@@ -10,9 +10,10 @@ slug: howto_enableanddisabledraggingatruntime_intercativityandux
 Your project might require you to enable or disable the Kendo UI Drag-and-Drop functionality during runtime.
 
 To achieve this behavior:
+
 1. Initialize the Drag-and-Drop feature on the parent container.
-1. Use a filter to specify which items will be draggable.
-1. Change the class of the items to enable and disable them.
+2. Use a filter to specify which items will be draggable.
+3. Change the class of the items to enable and disable them.
 
 The following example demonstrates how to accomplish this scenario.
 


### PR DESCRIPTION
Add the missing empty lines before the step lists which fixes the rendering of the numbered lists.