### PR TITLE
Editor: Add 'tableWizard' to list of tools available in API documentation

### DIFF
--- a/docs/api/javascript/ui/editor.md
+++ b/docs/api/javascript/ui/editor.md
@@ -2167,7 +2167,7 @@ The available editor commands are:
 *   Links, images and files
         - **createLink**, **unlink**, **insertImage**, **insertFile**
 *   Table editing
-        - **createTable**, **addColumnLeft**, **addColumnRight**, **addRowAbove**, **addRowBelow**, **deleteRow**, **deleteColumn**
+        - **tableWizard**, **createTable**, **addColumnLeft**, **addColumnRight**, **addRowAbove**, **addRowBelow**, **deleteRow**, **deleteColumn**
 *   Structural markup and styles
         - **formatting**, **cleanFormatting**
 *   Snippets


### PR DESCRIPTION
tableWizard is missing in the list of available tools.  It is listed in the Demo for the Editor under the All Tools demo.