### PR TITLE
Fix transport.read.contentType example in DataSource docs

### DIFF
--- a/docs/api/javascript/data/datasource.md
+++ b/docs/api/javascript/data/datasource.md
@@ -2362,7 +2362,7 @@ The content-type HTTP header sent to the server. The default is `"application/x-
     <script>
     var dataSource = new kendo.data.DataSource({
       transport: {
-        create: {
+        read: {
           /* omitted for brevity */
           contentType: "application/json"
         }


### PR DESCRIPTION
`transport.read.contentType` is using the example from `transport.create.contentType`