### PR TITLE
Add sample code to work around grouping in the original dataSource

### DIFF
--- a/docs/controls/data-management/grid/how-to/filtering/sort-multi-checkbox-filter.md
+++ b/docs/controls/data-management/grid/how-to/filtering/sort-multi-checkbox-filter.md
@@ -63,7 +63,10 @@ The following example demonstrates how to sort the Kendo UI multiple checkbox fi
                 var filterMultiCheck = this.thead.find("[data-field=" + e.field + "]").data("kendoFilterMultiCheck")
                 filterMultiCheck.container.empty();
                 filterMultiCheck.checkSource.sort({field: e.field, dir: "asc"});
-
+	
+                // uncomment the following line to handle any grouping from the original dataSource:
+	        // filterMultiCheck.checkSource.group(null);
+	
                 filterMultiCheck.checkSource.data(filterMultiCheck.checkSource.view().toJSON());
                 filterMultiCheck.createCheckBoxes();
               }


### PR DESCRIPTION
The sample throws an error if the original grid data has a grouping applied. The view() data returned in line 70 returns the original data sorted with the new sort configuration but also grouped by the original grouping.  Setting the checkSource group configuration to null fixes this case. This does not affect any group configuration in the original dataSource.