### PR TITLE
Fix scrolling root element if drag outside

### DIFF
--- a/src/kendo.draganddrop.js
+++ b/src/kendo.draganddrop.js
@@ -1064,7 +1064,7 @@ var __meta__ = { // jshint ignore:line
     }
 
     function scrollableRoot() {
-        return $(kendo.support.browser.chrome ? document.body : document.documentElement);
+        return $(kendo.support.browser.edge || kendo.support.browser.safari ? document.body : document.documentElement);
     }
 
     function findScrollableParent(element) {


### PR DESCRIPTION
Looks like chrome updated root scrollable element to HTML, but Edge - not