### PR TITLE
docs: tweak spelling error in Chat docs

### DIFF
--- a/docs/api/javascript/ui/chat.md
+++ b/docs/api/javascript/ui/chat.md
@@ -145,7 +145,7 @@ The layout to be used in rendering the attachments. Supported values are `list` 
 
 ##### sender `Object`
 
-The configuration object containg information about the sender of the message buggle. This determines where the message is rendered.
+The configuration object containg information about the sender of the message bubble. This determines where the message is rendered.
 
 ##### sender.id `Object`
 


### PR DESCRIPTION
Fixing a quick spelling mistake in the Chat's `renderAttachments` documentation section.

Side-note: used the "edit this article" feature of the docs, hopefully I didn't mess anything else up in the editing 😃 