### PR TITLE
Add String as an option for editable

### DIFF
--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -2660,7 +2660,7 @@ Check [Detail Template](http://demos.telerik.com/kendo-ui/grid/detailtemplate) f
     });
     </script>
 
-### editable `Boolean|Object` *(default: false)*
+### editable `Boolean|Object|String` *(default: false)*
 
 If set to `true` the user would be able to edit the data to which the grid is bound. By default editing is disabled.
 


### PR DESCRIPTION
Specifically, this option can be set to 'inline', 'popup' or 'incell' in addition to Boolean and Object.

(the main reason I'm doing this is so that the typescript definitions are updated for this component and my code will compile under TS 2.8)