### PR TITLE
Updated editor.md

### DIFF
--- a/docs/api/javascript/ui/editor.md
+++ b/docs/api/javascript/ui/editor.md
@@ -2404,7 +2404,7 @@ The code below shows how to use a template and pass variables to it. This allows
       tools: [
         {
           name: "custom",
-          myText: "Button Text"
+          myText: "Button Text",
           template: $("#toolTemplate").html()
         }
       ]


### PR DESCRIPTION
Missing ',' in example using a Kendo UI template with variables.