### PR TITLE
updated for missing ComboBox message

### DIFF
--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -404,6 +404,15 @@
         "noRecords": "Keine Datensätze verfügbar."
       });
   }
+  
+/* ComboBox messages */
+  
+if(kendo.ui.ListBox){
+kendo.ui.ComboBox.prototype.options.messages =
+$.extend(true, kendo.ui.ComboBox.prototype.options.messages,{
+  "noRecords": "Keine Datensätze verfügbar."
+});
+}
 
 /* ListBox messaages */
 


### PR DESCRIPTION
the german localization was missing a translation for the combobox "noRecords" message