### PR TITLE
Update kendo.all.d.ts

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -4370,7 +4370,7 @@ declare namespace kendo.ui {
         scrollable?: boolean | GridScrollable;
         selectable?: boolean|string;
         sortable?: boolean | GridSortable;
-        toolbar?: GridToolbarItem[];
+        toolbar?: (string|GridToolbarItem)[];
         beforeEdit?(e: GridBeforeEditEvent): void;
         cancel?(e: GridCancelEvent): void;
         cellClose?(e: GridCellCloseEvent): void;


### PR DESCRIPTION
the toolbar in GridOptions can be a mixed array of string|GridToolBarItem (i.e. ["create"])