### PR TITLE
Added missing sort method to ObservableArray.

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -1061,6 +1061,7 @@ declare namespace kendo.data {
         shift(): any;
         slice(begin: number, end?: number): any[];
         some(callback: (item: Object, index: number, source: ObservableArray) => boolean): boolean;
+        sort(compareFn?: (a: any, b: any) => number): any[];
         splice(start: number): any[];
         splice(start: number, deleteCount: number, ...items: any[]): any[];
         toJSON(): any[];


### PR DESCRIPTION
Added missing method to ObservableArray typescript definition.

This addresses #4883 