### PR TITLE
Do not unbind default events

### DIFF
--- a/docs/knowledge-base/grid-prevent-popup-close-on-edit.md
+++ b/docs/knowledge-base/grid-prevent-popup-close-on-edit.md
@@ -94,7 +94,7 @@ How can I keep the popup editor of the Grid open after I update or insert a reco
             editable: "popup",
             edit: function (e) {
                 var editWindow = this.editable.element.data("kendoWindow");
-                editWindow.unbind("close");
+               // editWindow.unbind("close");
                 editWindow.bind("close", onWindowEditClose);
             },
             save: function (e) {


### PR DESCRIPTION
There is a default event listener that is responsible to `cancelRow `on close and it is set as default option of `kendoWindow `used in `_createPopupEditor`.

The statement `editWindow.unbind("close");` detaches the default close listener. If it is removed then model changes will not destroy when user clicks on X close icon in window's action toolbar.

Same happens when it is provided as `editable.window.close`. It replaces the default listener and hence will cause the above mentioned issue.

STR:
1. Create New Record
2. Close window using X icon on right top of editor window

Expected Result:
New entry must be cleared from grid as it was not saved.

Actual Result:
Unsaved new record is present in the grid which leads to further errors on next row edit.