### PR TITLE
Fixed issue #4892 : Missing dataItems method for Grid in Typescript definitions

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -4082,6 +4082,7 @@ declare namespace kendo.ui {
         dataItem(row: string): kendo.data.ObservableObject;
         dataItem(row: Element): kendo.data.ObservableObject;
         dataItem(row: JQuery): kendo.data.ObservableObject;
+        dataItems(): kendo.data.ObservableArray;
         destroy(): void;
         editCell(cell: JQuery): void;
         editRow(row: JQuery): void;


### PR DESCRIPTION
In the TypeScript definitions file kendo.all.d.ts, the Grid class was missing a method (dataItems).
So the method was not recognized and generated an TypeScript error when using it.

The problem is referenced in issue #4892.

To fix the issue, I added the dataItems method declaration in the Grid class.

Sorry in advance if that's not the recommended way to fix the TypeScript definitions file.