### PR TITLE
fix issue #4255: optimization for listbox when transferring more than one item

### DIFF
--- a/src/kendo.listbox.js
+++ b/src/kendo.listbox.js
@@ -1288,13 +1288,18 @@ var __meta__ = { // jshint ignore:line
 
         getUpdatedSelection: function(items) {
             var that = this;
+
+            if ($(items).length !== 1) {
+                return null;
+            }
+
             var itemFilter = that.options.filter;
             var sourceListBox = that.getSourceListBox();
             var lastEnabledItem = sourceListBox ? sourceListBox.items().filter(itemFilter).last() : null;
             var containsLastItem = $(items).filter(lastEnabledItem).length > 0;
             var itemToSelect = containsLastItem ? $(items).prevAll(itemFilter)[0] : $(items).nextAll(itemFilter)[0];
 
-            if ($(items).length === 1 && itemToSelect) {
+            if (itemToSelect) {
                 return itemToSelect;
             } else {
                 return null;


### PR DESCRIPTION
This PR addresses one issue with the listbox control when transferring multiple items: #4255.

The method `getUpdatedSelection` gets called on transfer and is passed however many items you have selected in your listbox and returns the nearest item assuming the length of the items is equal to one otherwise null is returned. Well, since we are already know the length of the items there is no reason to perform the rest of the logic below. You could just return null right away if the length is not 1.

In my testing this line of code would get slower the more items you had selected `var itemToSelect = containsLastItem ? $(items).prevAll(itemFilter)[0] : $(items).nextAll(itemFilter)[0];`. By putting the length check above that code the performance improved significantly. 

I did look for other ways to improve the performance, but nothing really stood out as easy.