### PR TITLE
allow array of string be used as tools as well

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -3540,7 +3540,7 @@ declare namespace kendo.ui {
         resizable?: boolean | EditorResizable;
         serialization?: EditorSerialization;
         stylesheets?: any;
-        tools?: EditorTool[];
+        tools?: EditorTool[]|string[];
         imageBrowser?: EditorImageBrowser;
         fileBrowser?: EditorFileBrowser;
         change?(e: EditorEvent): void;


### PR DESCRIPTION
editor options should allow array of strings as well:
https://docs.telerik.com/kendo-ui/api/javascript/ui/editor/configuration/tools