### PR TITLE
Fix "SyntaxError: missing }"

### DIFF
--- a/docs/api/javascript/data/datasource.md
+++ b/docs/api/javascript/data/datasource.md
@@ -910,7 +910,7 @@ The aggregate results should have the following format:
     var dataSource = new kendo.data.DataSource({
       transport: {
         /* transport configuration */
-      }
+      },
       serverAggregates: true,
       schema: {
         aggregates: "aggregates" // aggregate results are returned in the "aggregates" field of the response


### PR DESCRIPTION
Fix "SyntaxError: missing } after property list at line 6" caused by missed comma.