### PR TITLE
Fix bind-treeview-checked-state example

### DIFF
--- a/docs/controls/navigation/treeview/how-to/AngularJS/bind-treeview-checked-state-to-custom-model-field.md
+++ b/docs/controls/navigation/treeview/how-to/AngularJS/bind-treeview-checked-state-to-custom-model-field.md
@@ -104,8 +104,10 @@ The following example demonstrates how to bind the checked state of a Kendo UI T
           for (var i = 0; i < model.length; i++) {
             var dataItem = model[i];
             var node = dataSource[i];
-
-            dataItem.isChecked = node.checked;
+            
+            if (node.checked != undefined) {
+              dataItem.isChecked = node.checked;
+            }
 
             if (dataItem.items) {
               updateChecked(dataItem.items, node.children.data());


### PR DESCRIPTION
The current example was overriding `isChecked` on items that are checked by default, but that kendo doesn't know about.

Example : 
* Modifiy the dojo to `console.log($scope.treeData)` after calling `updateChecked` in `check` event
* Run the dojo
* Uncheck `Reef`
* Check the log for `Coraline` which is now `isChecked: undefined`

In the exemple `Coraline`'s `isChecked` should have stayed `true`