### PR TITLE
[Model].set clean-up

### DIFF
--- a/src/kendo.data.js
+++ b/src/kendo.data.js
@@ -775,7 +775,7 @@ var __meta__ = { // jshint ignore:line
             return field ? field.editable !== false : true;
         },
 
-        set: function(field, value, initiator) {
+        set: function(field, value) {
             var that = this;
             var dirty = that.dirty;
 
@@ -786,7 +786,7 @@ var __meta__ = { // jshint ignore:line
                     that.dirty = true;
                     that.dirtyFields[field] = true;
 
-                    if (ObservableObject.fn.set.call(that, field, value, initiator) && !dirty) {
+                    if (ObservableObject.fn.set.call(that, field, value) && !dirty) {
                         that.dirty = dirty;
 
                         if (!that.dirty) {


### PR DESCRIPTION
"initiator" field comes always as undefined and causes problems when adding some features to [ObservableObject].set function (where it is redirected to). It is also not handled by [Model].set or [ObservableObject].set functions. So, I think it is an unused legacy code piece.