### PR TITLE
Changed startlabel to endlabel

### DIFF
--- a/docs/api/javascript/ui/daterangepicker.md
+++ b/docs/api/javascript/ui/daterangepicker.md
@@ -239,7 +239,7 @@ Allows localization of the strings that are used in the widget.
     $("#daterangepicker").kendoDateRangePicker({
         "messages": {
             "startLabel": "The Start",
-            "startLabel": "The End"
+            "endLabel": "The End"
         }
      })
     </script>


### PR DESCRIPTION
The messages example has the startlabel twice, it should be once and an endlabel.  Corrected second startlabel to endlabel.