### PR TITLE
Update datasource.md

### DIFF
--- a/docs/api/javascript/data/datasource.md
+++ b/docs/api/javascript/data/datasource.md
@@ -1136,7 +1136,7 @@ If set to an existing [`kendo.data.Model`](/api/javascript/data/model) instance,
               validation: { required: true }
             },
             UnitPrice: {
-              //data type of the field {Number|String|Boolean|Date} default is String
+              //data type of the field {number|string|boolean|date} default is string
               type: "number",
               // used when new model is created
               defaultValue: 42,
@@ -1165,7 +1165,7 @@ If set to an existing [`kendo.data.Model`](/api/javascript/data/model) instance,
           validation: { required: true }
         },
         UnitPrice: {
-          //data type of the field {Number|String|Boolean|Date} default is String
+          //data type of the field {number|string|boolean|date} default is string
           type: "number",
           // used when new model is created
           defaultValue: 42,


### PR DESCRIPTION
The text providing possible values for the type in the list of fields in Schema.Model.Fields should be lowercase.  Having uppercase values implies that uppercase values will work for the type, and that is not true in every case.  Specifically, uppercase values in the type field will cause the row filtering to not properly apply the autocomplete widget to inline row editing text boxes in the filter row.