### PR TITLE
docs(diagram): addShape should not be used when using a data source

### DIFF
--- a/docs/api/javascript/dataviz/ui/diagram.md
+++ b/docs/api/javascript/dataviz/ui/diagram.md
@@ -7073,7 +7073,7 @@ Whether the addition should be recorded in the undo-redo stack.
 
 ### addShape
 
-Adds a new shape to the diagram.
+Adds a new shape to the diagram. If the diagram is bound to a data source, do not use `addShae(newShape)`. Instead, use `diagram.dataSource.add(newShape);` and optionally `.sync()` the data source.
 
 #### Parameters
 


### PR DESCRIPTION
I found numerous threads online where we advise people to use `addShape` only for local data, but to update the data source if it is in use. Perhaps this should be extended to `addConnection` too. This method is, however, used in the `Example - get Model coordinates of dragged HTML element` section when the diagram is bound to a data source. This is why I am leaving this as a pull request so someone familiar with the component can evaluate.