### PR TITLE
Update datepicker docs to reflect accurate max date default value

### DIFF
--- a/docs/api/javascript/ui/datepicker.md
+++ b/docs/api/javascript/ui/datepicker.md
@@ -302,7 +302,7 @@ note that a check for an empty `date` is needed, as the widget can work with a n
     });
     </script>
 
-### max `Date`*(default: Date(2099, 11, 31))*
+### max `Date`*(default: Date(2099, 12, 31))*
 
  Specifies the maximum date, which the calendar can show.
 


### PR DESCRIPTION
* Update datepicker.md docs to reflect accurate max date default value

Note: As is, the documentation lists November as having 31 days, which it doesn't. Code sets the default max date to December 31, 2099 however.