### PR TITLE
Updated outdated link to grid.columns.locked telerik/kendo-ui-core#5559

### DIFF
--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -2157,7 +2157,7 @@ If set to `true` the column will not be displayed in the grid. By default all co
 
 ### columns.locked `Boolean` *(default: false)*
 
-If set to `true` the column will be displayed as locked (frozen) in the grid. Also see the information about [Locked Columns](/controls/data-management/grid/appearance#locked-columns) in the Grid Appearance article.
+If set to `true` the column will be displayed as locked (frozen) in the grid. Also see [Locked Columns](/controls/data-management/grid/columns/locked-columns) help section for additional information.
 
 > **Important**: Row template and detail features are not supported in combination with column locking. If [multi-column headers](http://demos.telerik.com/kendo-ui/grid/multicolumnheaders) are used, it is possible to lock (freeze) a column at the topmost level only.
 


### PR DESCRIPTION
Links was to https://docs.telerik.com/kendo-ui/controls/data-management/grid/appearance#locked-columns , should be to https://docs.telerik.com/kendo-ui/controls/data-management/grid/columns/locked-columns 