### PR TITLE
Update datepicker-remove-year-view.md

### DIFF
--- a/docs/knowledge-base/datepicker-remove-year-view.md
+++ b/docs/knowledge-base/datepicker-remove-year-view.md
@@ -74,9 +74,9 @@ The following example demonstrates how to hide the year view in a Kendo UI DateP
                 if (view.name === "year") {
                     cal.element.find(".k-header").css("display", "none");
                 } else {
-                    var navFast = $(".k-nav-fast");
+                    var navFast = cal.element.find(".k-nav-fast");
 
-                    var dsa = cal.element.find(".k-header").css("display", "block");
+                    cal.element.find(".k-header").css("display", "block");
                     navFast[0].innerText = navFast[0].innerText.slice(0, -5);
                 }
 
@@ -137,9 +137,9 @@ The following example demonstrates how to hide the year view in a Kendo UI DateT
                     if (view.name === "year") {
                         cal.element.find(".k-header").css("display", "none");
                     } else {
-                        var navFast = $(".k-nav-fast");
+                        var navFast = cal.element.find(".k-nav-fast");
 
-                        var dsa = cal.element.find(".k-header").css("display", "block");
+                        cal.element.find(".k-header").css("display", "block");
                         navFast[0].innerText = navFast[0].innerText.slice(0, -5);
                     }
 


### PR DESCRIPTION
I found that if there more than one datepicker rendered on a page, it's good to find '.k-nav-fast' for respective selected calendar instead of querying the whole dom elements.