### PR TITLE
Update kendo.all.d.ts telerik/kendo-ui-core#5765

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -10027,7 +10027,7 @@ declare namespace kendo.ui {
         messages?: any;
         rules?: any;
         validateOnBlur?: boolean;
-        validationSummary: boolean | ValidationSummary;
+        validationSummary?: boolean | ValidationSummary;
         validate?(e: ValidatorValidateEvent): void;
         validateInput?(e: ValidatorValidateInputEvent): void;
     }


### PR DESCRIPTION
Set ValidatorOptions.validationSummary to be optional. It defaults to false and shouldn't be required.