### PR TITLE
Fixed error in custom validation example

### DIFF
--- a/docs/controls/layout/form/validation.md
+++ b/docs/controls/layout/form/validation.md
@@ -186,7 +186,7 @@ The following example demonstrates custom validation of the `RetireDate` field.
                                     if (input.is("[name='RetireDate']") && input.val() != "") {
                                         var date = kendo.parseDate(input.val()),
                                             hireDate = kendo.parseDate($("[name='HireDate']").val());
-                                        input.attr("data-RetireDatevalidation-msg", "Retire Date should be after Hire Date");
+                                        input.attr("data-greaterdate-msg", "Retire Date should be after Hire Date");
                                         return hireDate == null || hireDate.getTime() < date.getTime();
                                     }
 


### PR DESCRIPTION
The error message shown was "RetireDate" insetad of "Retire Date should be after Hire Date".