### PR TITLE
Update tilelayout.md

### DIFF
--- a/docs/api/javascript/ui/tilelayout.md
+++ b/docs/api/javascript/ui/tilelayout.md
@@ -643,7 +643,7 @@ Fired when a tile item is resized.
 
 #### Event Data
 
-##### e.container `jQuery`
+##### e.item `jQuery`
 
 A jQuery object representing the resized item.
 
@@ -682,7 +682,7 @@ The widget instance which fired the event.
         columns: 4,
         resizable: true,
         resize: function (e) {
-            console.log(e.container[0]);
+            console.log(e.item[0]);
         }
     });
     </script>


### PR DESCRIPTION
There is no 'container' object in a resize event. There is object named 'item'.  'container' exists only in reorder event. Tested on Kendo 2020.2.513