### PR TITLE
Allow OData-V4 Batch requests to be customized like other requests

### DIFF
--- a/src/kendo.data.odata.js
+++ b/src/kendo.data.odata.js
@@ -267,7 +267,7 @@ var __meta__ = { // jshint ignore:line
     }
 
     function createBatchRequest(transport, colections) {
-        var options = {};
+		var options = extend({}, transport.options.batch);
         var boundary = createBoundary("sf_batch_");
         var requestBody = "";
         var changeId = 0;
@@ -276,9 +276,9 @@ var __meta__ = { // jshint ignore:line
 
         options.type = transport.options.batch.type;
         options.url = isFunction(batchURL) ? batchURL() : batchURL;
-        options.headers = {
-            "Content-Type": "multipart/mixed; boundary=" + boundary
-        };
+		options.headers = extend(options.headers || {}, {
+			"Content-Type": "multipart/mixed; boundary=" + boundary
+		});
 
         if (colections.updated.length) {
             requestBody += processCollection(colections.updated, boundary, changeset, changeId, transport, "update", false);


### PR DESCRIPTION
This PR adjusts the "odata-v4" transport to populate the $.ajax() call by extending the options passed into the transport definition instead of creating new ones from scratch. Brings it in line with how the other requests are processed.

Fixes #6006.