### PR TITLE
Update kendo.all.d.ts with Spreadsheet saveJSON (#6043)

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -8307,6 +8307,7 @@ declare namespace kendo.ui {
         refresh(): void;
         removeSheet(sheet: kendo.spreadsheet.Sheet): void;
         renameSheet(sheet: kendo.spreadsheet.Sheet, newSheetName: string): kendo.spreadsheet.Sheet;
+        saveJSON(): JQueryPromise<any>;
         toJSON(): any;
         fromJSON(data: any): void;
         defineName(name: string, value: string, hidden: boolean): void;


### PR DESCRIPTION
Include type definition for Spreadsheet saveJSON method as described here in the docs: https://docs.telerik.com/kendo-ui/api/javascript/ui/spreadsheet/methods/savejson#savejson

Fixes #6043