### PR TITLE
Update kendo.all.d.ts

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -4147,8 +4147,8 @@ declare namespace kendo.ui {
         navigate(): void;
         refresh(): void;
         executeCommand(): void;
-        getSelected(): void;
-        getSize(): void;
+        getSelected(): any | any[];
+        getSize(): any;
         destroy(): void;
         setDataSource(dataSource: kendo.data.FileManagerDataSource): void;
         items(): any;


### PR DESCRIPTION
Replaced some `void` with `any` as return types of `FileManager.getSelected()` and `FileManager.getSize()`. Voids can't be tested nor cast to bool and cause tons of compilation errors.