### PR TITLE
Add missing de-DE translation for kendo.ui.DateInput

### DIFF
--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -645,6 +645,22 @@ $.extend(true, kendo.ui.ListBox.prototype.options.messages,{
         "cancel": "Abbrechen"
       });
   }
+  
+  /* DateInput */
+  
+  if (kendo.ui.DateInput) {
+    kendo.ui.DateInput.prototype.options.messages =
+      $.extend(true, kendo.ui.DateInput.prototype.options.messages, {
+        "year": "Jahr",
+        "month": "Monat",
+        "day": "Tag",
+        "weekday": "Wochentag",
+        "hour": "Stunde",
+        "minute": "Minute",
+        "second": "Sekunde",
+        "dayperiod": "AM/PM"
+       });
+    }
 
   /* FlatColorPicker messages */
 


### PR DESCRIPTION
Based on the issue described in https://www.telerik.com/forums/missing-translation(-) this pull request adds missing `de-DE` translation for kendo.ui.DateInput component. I inserted the new translation at the same position as in [kendo.messages.en-US.js#L1205-L1218](https://github.com/telerik/kendo-ui-core/blob/master/src/messages/kendo.messages.en-US.js#L1205-L1218) (after `kendo.ui.Prompt`).

before:
![image](https://user-images.githubusercontent.com/8781699/103782715-1673a380-5038-11eb-8953-b359eadf9198.png)

after:
![image](https://user-images.githubusercontent.com/8781699/103782759-27bcb000-5038-11eb-9a29-48eee34ae3e0.png)

I created this example https://dojo.telerik.com/oTAniveC for demonstration purposes.
