### PR TITLE
Fix highlight problem on second search

### DIFF
--- a/docs/knowledge-base/combobox-highlight-matched-text.md
+++ b/docs/knowledge-base/combobox-highlight-matched-text.md
@@ -43,24 +43,44 @@ Implement the `dataBound` event handler for the widget.
     var items = combo.items();
     var inputText = $('.k-input').val().toLowerCase();
 
-	for (var i = 0; i < items.length; i += 1) {
+    for (var i = 0; i < items.length; i += 1) {
       var item = $(items[i]);
       var itemHtml = item.html();
       var startIndex = itemHtml.toLowerCase().indexOf(inputText);
-      var endIndex = startIndex + inputText.length;
+      if(startIndex>=0){  // Only highlighted the items which contain the search text
+        var endIndex = startIndex + inputText.length;
+        var outputHtml = [
+          itemHtml.slice(0, startIndex),
+          '<span class="highlight">',
+          itemHtml.slice(startIndex, endIndex),
+          '</span>',
+          itemHtml.slice(endIndex)
+        ].join('');
 
-	  var outputHtml = [
-		itemHtml.slice(0, startIndex),
-		'<span class="highlight">',
-		itemHtml.slice(startIndex, endIndex),
-		'</span>',
-		itemHtml.slice(endIndex)
-	  ].join('');
-
-	  item.html(outputHtml);
+        item.html(outputHtml);
+      }
     }
   }
 
+  // Remove highlight after seleting the event. Otherwise dropdown always highlighted the item which has been selected frist time after searching text.
+  function removeHighlight(e) {
+    var combo = e.sender;
+    var items = combo.items();
+    var inputText = $('.k-input').val().toLowerCase();
+    
+    for (var i = 0; i < items.length; i += 1) {
+      var item = $(items[i]);
+      var itemHtml = item.html();
+      var startIndex = itemHtml.toLowerCase().indexOf(inputText);
+      if (startIndex > 0) {
+        if (item.find('span.highlight').length > 0) { 
+          var itemText = item.text();
+          item.html(itemText);
+        }
+      }
+    }
+  }
+  
   $(document).ready(function() {
     $("#products").kendoComboBox({
       placeholder: "Select product",
@@ -76,6 +96,13 @@ Implement the `dataBound` event handler for the widget.
           read: {
             url: "https://demos.telerik.com/kendo-ui/service/Northwind.svc/Products",
           }
+        }
+      },
+      select: function (e) {
+      	var item = e.dataItem;
+	// This checking is required. issue in kendo dropdown : the select event is triggered on blur, although it is not needed
+        if (item !== null) {
+          removeHighlight(e);
         }
       }
     });


### PR DESCRIPTION
**Only highlighted the items which contain the search text .** 
Step to reproduce:
    - Search items with a specific text
    - Select one item from drop-down
    - Expand/open the drop-down again.  Some items (text) are wrongly highlighted

**Remove highlight of previous item after selecting item**
Step to reproduce:
   -Search and select an item from drop-down
  - Expand/open the drop-down and select another item.
  - Expand/open the drop-down again and it will show the first item that has been selected through search text.