### PR TITLE
Added missing properties to the Chart, Scheduler, ProgressBar

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -631,6 +631,7 @@ declare namespace kendo.data {
         };
         id: any;
         dirty: boolean;
+        dirtyFields: any[];
 
         static define(options: DataSourceSchemaModelWithFieldsObject): typeof Model;
         static define(options: DataSourceSchemaModelWithFieldsArray): typeof Model;
@@ -7866,7 +7867,7 @@ declare namespace kendo.ui {
 
         enable(enable: boolean): void;
         value(): number;
-        value(value: number): void;
+        value(value: boolean|number): void;
 
     }
 
@@ -8436,9 +8437,11 @@ declare namespace kendo.ui {
         allDaySlot?: boolean;
         allDaySlotTemplate?: string|Function;
         columnWidth?: number;
+        content?: JQuery;
         dateHeaderTemplate?: string|Function;
         dayTemplate?: string|Function;
         editable?: boolean | SchedulerViewEditable;
+        endDate?(): Date;
         endTime?: Date;
         eventHeight?: number | string;
         eventSpacing?: number;
@@ -8456,12 +8459,12 @@ declare namespace kendo.ui {
         selectedShortDateFormat?: string;
         showWorkHours?: boolean;
         slotTemplate?: string|Function;
+        startDate?(): Date;
         startTime?: Date;
         title?: string;
         type?: string;
         workWeekStart?: number;
         workWeekEnd?: number;
-        startDate?(): Date;
     }
 
     interface SchedulerOptions {
@@ -14989,12 +14992,14 @@ declare namespace kendo.dataviz.ui {
         type?: string;
         name?: string;
         data?: any;
+        field?: string;
     }
 
     interface ChartSeriesHoverEventSeries {
         type?: string;
         name?: string;
         data?: any;
+        field?: string;
     }
 
     interface ChartSeriesOverEventSeries {


### PR DESCRIPTION
Added some missing properties in the typedefinition, that I always had to add manually after a Kendo upgrade