### PR TITLE
Fix pageable.messages.itemsPerPage Example

### DIFF
--- a/docs/api/javascript/ui/treelist.md
+++ b/docs/api/javascript/ui/treelist.md
@@ -4354,7 +4354,7 @@ The label that is displayed after the drop-down list for the page size.
                 ]
             },
             pageable: {
-                pageSize: 2,
+                pageSizes: [2,3],
                 input: true,
                 messages: {
                     itemsPerPage: "data items per page"


### PR DESCRIPTION
The [example](https://docs.telerik.com/kendo-ui/api/javascript/ui/treelist/configuration/pageable.messages.itemsperpage) tries to show how messages.itemsPerPage displays a message after the page size dropdown, but it doesn't because there is no page size dropdown. I'm adding a page size dropdown so that the messages.itemsPerPage string is displayed.