### PR TITLE
Update setup-private-nuget-feed-azure.md

### DIFF
--- a/docs-aspnet/knowledge-base/setup-private-nuget-feed-azure.md
+++ b/docs-aspnet/knowledge-base/setup-private-nuget-feed-azure.md
@@ -62,7 +62,9 @@ The NuGet config file allows you to set package sources as well as where to get 
             </packageSourceCredentials>
         </configuration>
 
-However this could be a security issue in a CI/CD environment where another user might be able to read the values of environment variables. The [Azure DevOps Service Connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml) resolves this as it lets you enter credentials in a secure manner without unnecessarily exposing account details. That Service Connection can now be used by multiple pipelines to authenticate private NuGet feeds (and other services that need authentication).
+However, this could be a security issue in a CI/CD environment where another user might be able to read the values of environment variables. The [Azure DevOps Service Connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml) resolves this as it lets you enter credentials in a secure manner without unnecessarily exposing account details. That Service Connection can now be used by multiple pipelines to authenticate private NuGet feeds (and other services that need authentication).
+
+> You cannot use `Password` instead of `ClearTextPassword`. This is because Password is an encrypted value, set on a specific Windows machine, and is only supported on Windows. See the [NuGet packageSourceCredentials documentation](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#packagesourcecredentials) for more information.
 
 ### Setting up the Service Connection
 


### PR DESCRIPTION
Added a note to clarify that `Password` is not supported in nuget.config, only that `ClearTextPassword` can be used.