### PR TITLE
Improve performance of expand/collapse function telerik/kendo-ui-core#6512

### DIFF
--- a/docs/knowledge-base/gantt-expand-collapse-alltasks.md
+++ b/docs/knowledge-base/gantt-expand-collapse-alltasks.md
@@ -1,6 +1,6 @@
 ---
 title: Expand and Collapse All Gantt Rows
-description: An example on how to implement a functionality to expand and collapse all kendo UI Gantt tasks.
+description: An example on how to implement a functionality to expand and collapse all Kendo UI Gantt tasks.
 type: how-to
 page_title: Implement Expand and Collapse All Tasks on a Button Click | Kendo UI Gantt for jQuery
 slug: gantt-expand-collapse-alltasks
@@ -18,7 +18,7 @@ res_type: kb
  </tr>
  <tr>
   <td>Operating System</td>
-  <td>Windows 7 64bit</td>
+  <td>Windows 10 64bit</td>
  </tr>
  <tr>
   <td>Browser</td>
@@ -26,7 +26,7 @@ res_type: kb
  </tr>
  <tr>
   <td>Browser Version</td>
-  <td>Version 62.0.3202.94 (Official Build) (64-bit)</td>
+  <td>Version 92.0.4515.131 (Official Build) (64-bit)</td>
  </tr>
 </table>
 
@@ -40,7 +40,8 @@ How can I add a button which will expand or collapse all tasks in my Gantt?
 1. Add a button to your page and subscribe for its `click` event.
 1. In the `click` function, get a reference to the DataSource of the Gantt (all tasks that are rendered in it).
 1. Implement a loop to iterate through all tasks.
-1. Use `set("expanded", [true/false])` to manage the expanded state.
+1. Set the `expanded` property of each tasks.
+1. Refresh the Gantt using its `refresh()` method.
 
 ```dojo
 
@@ -53,12 +54,20 @@ How can I add a button which will expand or collapse all tasks in my Gantt?
     <script>
         $(document).ready(function() {
             $(".k-button").click(function(e) {
-                var tasks = $("#gantt").data("kendoGantt").dataSource.view();
-                var shouldExpand = !tasks[0].expanded;
-                for (i = 0; i < tasks.length; i++) {
+                let gantt = $("#gantt").data("kendoGantt");
+                let tasks = gantt.dataSource.view();
 
-                    tasks[i].set("expanded", shouldExpand)
+                if (!tasks.length) {
+                    return;
                 }
+
+                let shouldExpand = !tasks[0].expanded;
+
+                tasks.forEach((task) => {
+                    task.expanded = shouldExpand;
+                });
+
+                gantt.refresh();
             })
 
             var serviceRoot = "https://demos.telerik.com/kendo-ui/service";


### PR DESCRIPTION
The previous version takes multiple seconds complete for a Gantt consisting of around 40 tasks.
Now, the `expanded` property of the tasks is directly assigned instead of using the `set()` method.

This requires the Gantt to be refreshed in the end. Nevertheless, performance is increased significantly.