### PR TITLE
Fixing typo when generating copy of the date.

### DIFF
--- a/docs/knowledge-base/date-format-excel-export-grid.md
+++ b/docs/knowledge-base/date-format-excel-export-grid.md
@@ -66,7 +66,7 @@ How can I change the format of a date column during the Excel export in the Kend
                 for (var q = 0; q < dateCells.length; q++) {
                     var cellIndex = dateCells[q];
                     var value = row.cells[cellIndex].value;
-                    var newValue = new Date(value.getFullYear(), value.getMonth(), value.getDay());
+                    var newValue = new Date(value.getFullYear(), value.getMonth(), value.getDate());
 
                     row.cells[cellIndex].value = newValue;
                     row.cells[cellIndex].format = "yyyy-MM-dd";


### PR DESCRIPTION
In the line 69 there was used wrong function instead of getDay() should be getDate(). 
The getDay() returns day of the week instead of day of the month which as an outcome generates wrong new Date from previous value.

This fix may save people some time on finding why this is not always working as expected.