### PR TITLE
Fixed missing / broken methods in Calendar

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -2645,7 +2645,8 @@ declare namespace kendo.ui {
         navigateToFuture(): void;
         navigateToPast(): void;
         navigateUp(): void;
-        selectDates(): void;
+        selectDates(): any;
+        selectDates(dates: any): void;
         value(): Date;
         value(value: Date): void;
         value(value: string): void;


### PR DESCRIPTION
Both signatures for Calendar.selectDates() have problems, and this pull request solves them:

 - The get method was marked void, and it definitely needs to return a value.  
 - The set method did not exist at all.
 
This page shows how these methods should work, so you can easily see what I'm solving: https://docs.telerik.com/kendo-ui/api/javascript/ui/calendar/methods/selectdates