### PR TITLE
PDFViewer german translation

### DIFF
--- a/src/messages/kendo.messages.de-AT.js
+++ b/src/messages/kendo.messages.de-AT.js
@@ -630,62 +630,62 @@
   if (kendo.ui.PDFViewer) {
     kendo.ui.PDFViewer.prototype.options.messages =
         $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
-            defaultFileName: 'Mein Dokument',
+            defaultFileName: "Mein Dokument",
             toolbar: {
                 zoom: {
-                    zoomOut: 'Herauszoomen',
-                    zoomIn: 'Hineinzoomen',
-                    actualWidth: 'Tatsächliche Breite',
-                    autoWidth: 'Automatische Breite',
-                    fitToWidth: 'An Breite anpassen',
-                    fitToPage: 'An Seite anpassen'
+                    zoomOut: "Herauszoomen",
+                    zoomIn: "Hineinzoomen",
+                    actualWidth: "Tatsächliche Breite",
+                    autoWidth: "Automatische Breite",
+                    fitToWidth: "An Breite anpassen",
+                    fitToPage: "An Seite anpassen"
                 },
-                open: 'Öffnen',
-                exportAs: 'Exportieren',
-                download: 'Herunterladen',
+                open: "Öffnen",
+                exportAs: "Exportieren",
+                download: "Herunterladen",
                 pager: {
-                    first: 'Zur ersten Seite',
-                    previous: 'Zur vorherigen Seite',
-                    next: 'Zur nächsten Seite',
-                    last: 'Zur letzten Seite',
-                    of: ' von {0} ',
-                    page: 'Seite',
-                    pages: 'Seiten'
+                    first: "Zur ersten Seite",
+                    previous: "Zur vorherigen Seite",
+                    next: "Zur nächsten Seite",
+                    last: "Zur letzten Seite",
+                    of: " von {0} ",
+                    page: "Seite",
+                    pages: "Seiten"
                 },
-                print: 'Drucken',
-                toggleSelection: 'Markierungsmodus',
-                togglePan: 'Schwenkmodus',
-                search: 'Suchen'
+                print: "Drucken",
+                toggleSelection: "Markierungsmodus",
+                togglePan: "Schwenkmodus",
+                search: "Suchen"
             },
             errorMessages: {
-                notSupported: 'Dateityp nicht unterstützt.',
-                parseError: 'Fehler beim Verarbeiten der Datei.',
-                notFound: 'Datei konnte nicht gefunden werden.',
-                popupBlocked: 'Popups sind blockiert.'
+                notSupported: "Dateityp nicht unterstützt.",
+                parseError: "Fehler beim Verarbeiten der Datei.",
+                notFound: "Datei konnte nicht gefunden werden.",
+                popupBlocked: "Popups sind blockiert."
             },
             dialogs: {
                 exportAsDialog: {
-                    title: 'Exportieren...',
-                    defaultFileName: 'Dokument',
-                    pdf: 'Portable Document Format (.pdf)',
-                    png: 'Portable Network Graphics (.png)',
-                    svg: 'Scalable Vector Graphics (.svg)',
+                    title: "Exportieren...",
+                    defaultFileName: "Dokument",
+                    pdf: "Portable Document Format (.pdf)",
+                    png: "Portable Network Graphics (.png)",
+                    svg: "Scalable Vector Graphics (.svg)",
                     labels: {
-                        fileName: 'Dateiname',
-                        saveAsType: 'Speichern als',
-                        page: 'Seite'
+                        fileName: "Dateiname",
+                        saveAsType: "Speichern als",
+                        page: "Seite"
                     }
                 },
-                okText: 'OK',
-                save: 'Speichern',
-                cancel: 'Abbrechen',
+                okText: "OK",
+                save: "Speichern",
+                cancel: "Abbrechen",
                 search: {
-                    inputLabel: 'Suchtext',
-                    matchCase: 'Groß-/Kleinschreibung beachten',
-                    next: 'Nächster Treffer',
-                    previous: 'Vorheriger Treffer',
-                    close: 'Schließen',
-                    of: 'von'
+                    inputLabel: "Suchtext",
+                    matchCase: "Groß-/Kleinschreibung beachten",
+                    next: "Nächster Treffer",
+                    previous: "Vorheriger Treffer",
+                    close: "Schließen",
+                    of: "von"
                 }
             }
         });

--- a/src/messages/kendo.messages.de-AT.js
+++ b/src/messages/kendo.messages.de-AT.js
@@ -624,5 +624,71 @@
         "cancel": "Abbrechen"
       });
   }
+  
+  /* PDFViewer */
+  
+  if (kendo.ui.PDFViewer) {
+    kendo.ui.PDFViewer.prototype.options.messages =
+        $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
+            defaultFileName: 'Mein Dokument',
+            toolbar: {
+                zoom: {
+                    zoomOut: 'Herauszoomen',
+                    zoomIn: 'Hineinzoomen',
+                    actualWidth: 'Tatsächliche Breite',
+                    autoWidth: 'Automatische Breite',
+                    fitToWidth: 'An Breite anpassen',
+                    fitToPage: 'An Seite anpassen'
+                },
+                open: 'Öffnen',
+                exportAs: 'Exportieren',
+                download: 'Herunterladen',
+                pager: {
+                    first: 'Zur ersten Seite',
+                    previous: 'Zur vorherigen Seite',
+                    next: 'Zur nächsten Seite',
+                    last: 'Zur letzten Seite',
+                    of: ' von {0} ',
+                    page: 'Seite',
+                    pages: 'Seiten'
+                },
+                print: 'Drucken',
+                toggleSelection: 'Markierungsmodus',
+                togglePan: 'Schwenkmodus',
+                search: 'Suchen'
+            },
+            errorMessages: {
+                notSupported: 'Dateityp nicht unterstützt.',
+                parseError: 'Fehler beim Verarbeiten der Datei.',
+                notFound: 'Datei konnte nicht gefunden werden.',
+                popupBlocked: 'Popups sind blockiert.'
+            },
+            dialogs: {
+                exportAsDialog: {
+                    title: 'Exportieren...',
+                    defaultFileName: 'Dokument',
+                    pdf: 'Portable Document Format (.pdf)',
+                    png: 'Portable Network Graphics (.png)',
+                    svg: 'Scalable Vector Graphics (.svg)',
+                    labels: {
+                        fileName: 'Dateiname',
+                        saveAsType: 'Speichern als',
+                        page: 'Seite'
+                    }
+                },
+                okText: 'OK',
+                save: 'Speichern',
+                cancel: 'Abbrechen',
+                search: {
+                    inputLabel: 'Suchtext',
+                    matchCase: 'Groß-/Kleinschreibung beachten',
+                    next: 'Nächster Treffer',
+                    previous: 'Vorheriger Treffer',
+                    close: 'Schließen',
+                    of: 'von'
+                }
+            }
+        });
+  }
 
 })(window.kendo.jQuery);

--- a/src/messages/kendo.messages.de-CH.js
+++ b/src/messages/kendo.messages.de-CH.js
@@ -623,5 +623,71 @@
         "cancel": "Abbrechen"
       });
   }
+  
+  /* PDFViewer */
+  
+  if (kendo.ui.PDFViewer) {
+    kendo.ui.PDFViewer.prototype.options.messages =
+        $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
+            defaultFileName: 'Mein Dokument',
+            toolbar: {
+                zoom: {
+                    zoomOut: 'Herauszoomen',
+                    zoomIn: 'Hineinzoomen',
+                    actualWidth: 'Tatsächliche Breite',
+                    autoWidth: 'Automatische Breite',
+                    fitToWidth: 'An Breite anpassen',
+                    fitToPage: 'An Seite anpassen'
+                },
+                open: 'Öffnen',
+                exportAs: 'Exportieren',
+                download: 'Herunterladen',
+                pager: {
+                    first: 'Zur ersten Seite',
+                    previous: 'Zur vorherigen Seite',
+                    next: 'Zur nächsten Seite',
+                    last: 'Zur letzten Seite',
+                    of: ' von {0} ',
+                    page: 'Seite',
+                    pages: 'Seiten'
+                },
+                print: 'Drucken',
+                toggleSelection: 'Markierungsmodus',
+                togglePan: 'Schwenkmodus',
+                search: 'Suchen'
+            },
+            errorMessages: {
+                notSupported: 'Dateityp nicht unterstützt.',
+                parseError: 'Fehler beim Verarbeiten der Datei.',
+                notFound: 'Datei konnte nicht gefunden werden.',
+                popupBlocked: 'Popups sind blockiert.'
+            },
+            dialogs: {
+                exportAsDialog: {
+                    title: 'Exportieren...',
+                    defaultFileName: 'Dokument',
+                    pdf: 'Portable Document Format (.pdf)',
+                    png: 'Portable Network Graphics (.png)',
+                    svg: 'Scalable Vector Graphics (.svg)',
+                    labels: {
+                        fileName: 'Dateiname',
+                        saveAsType: 'Speichern als',
+                        page: 'Seite'
+                    }
+                },
+                okText: 'OK',
+                save: 'Speichern',
+                cancel: 'Abbrechen',
+                search: {
+                    inputLabel: 'Suchtext',
+                    matchCase: 'Gross-/Kleinschreibung beachten',
+                    next: 'Nächster Treffer',
+                    previous: 'Vorheriger Treffer',
+                    close: 'Schliessen',
+                    of: 'von'
+                }
+            }
+        });
+  }
 
 })(window.kendo.jQuery);

--- a/src/messages/kendo.messages.de-CH.js
+++ b/src/messages/kendo.messages.de-CH.js
@@ -629,62 +629,62 @@
   if (kendo.ui.PDFViewer) {
     kendo.ui.PDFViewer.prototype.options.messages =
         $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
-            defaultFileName: 'Mein Dokument',
+            defaultFileName: "Mein Dokument",
             toolbar: {
                 zoom: {
-                    zoomOut: 'Herauszoomen',
-                    zoomIn: 'Hineinzoomen',
-                    actualWidth: 'Tatsächliche Breite',
-                    autoWidth: 'Automatische Breite',
-                    fitToWidth: 'An Breite anpassen',
-                    fitToPage: 'An Seite anpassen'
+                    zoomOut: "Herauszoomen",
+                    zoomIn: "Hineinzoomen",
+                    actualWidth: "Tatsächliche Breite",
+                    autoWidth: "Automatische Breite",
+                    fitToWidth: "An Breite anpassen",
+                    fitToPage: "An Seite anpassen"
                 },
-                open: 'Öffnen',
-                exportAs: 'Exportieren',
-                download: 'Herunterladen',
+                open: "Öffnen",
+                exportAs: "Exportieren",
+                download: "Herunterladen",
                 pager: {
-                    first: 'Zur ersten Seite',
-                    previous: 'Zur vorherigen Seite',
-                    next: 'Zur nächsten Seite',
-                    last: 'Zur letzten Seite',
-                    of: ' von {0} ',
-                    page: 'Seite',
-                    pages: 'Seiten'
+                    first: "Zur ersten Seite",
+                    previous: "Zur vorherigen Seite",
+                    next: "Zur nächsten Seite",
+                    last: "Zur letzten Seite",
+                    of: " von {0} ",
+                    page: "Seite",
+                    pages: "Seiten"
                 },
-                print: 'Drucken',
-                toggleSelection: 'Markierungsmodus',
-                togglePan: 'Schwenkmodus',
-                search: 'Suchen'
+                print: "Drucken",
+                toggleSelection: "Markierungsmodus",
+                togglePan: "Schwenkmodus",
+                search: "Suchen"
             },
             errorMessages: {
-                notSupported: 'Dateityp nicht unterstützt.',
-                parseError: 'Fehler beim Verarbeiten der Datei.',
-                notFound: 'Datei konnte nicht gefunden werden.',
-                popupBlocked: 'Popups sind blockiert.'
+                notSupported: "Dateityp nicht unterstützt.",
+                parseError: "Fehler beim Verarbeiten der Datei.",
+                notFound: "Datei konnte nicht gefunden werden.",
+                popupBlocked: "Popups sind blockiert."
             },
             dialogs: {
                 exportAsDialog: {
-                    title: 'Exportieren...',
-                    defaultFileName: 'Dokument',
-                    pdf: 'Portable Document Format (.pdf)',
-                    png: 'Portable Network Graphics (.png)',
-                    svg: 'Scalable Vector Graphics (.svg)',
+                    title: "Exportieren...",
+                    defaultFileName: "Dokument",
+                    pdf: "Portable Document Format (.pdf)",
+                    png: "Portable Network Graphics (.png)",
+                    svg: "Scalable Vector Graphics (.svg)",
                     labels: {
-                        fileName: 'Dateiname',
-                        saveAsType: 'Speichern als',
-                        page: 'Seite'
+                        fileName: "Dateiname",
+                        saveAsType: "Speichern als",
+                        page: "Seite"
                     }
                 },
-                okText: 'OK',
-                save: 'Speichern',
-                cancel: 'Abbrechen',
+                okText: "OK",
+                save: "Speichern",
+                cancel: "Abbrechen",
                 search: {
-                    inputLabel: 'Suchtext',
-                    matchCase: 'Gross-/Kleinschreibung beachten',
-                    next: 'Nächster Treffer',
-                    previous: 'Vorheriger Treffer',
-                    close: 'Schliessen',
-                    of: 'von'
+                    inputLabel: "Suchtext",
+                    matchCase: "Gross-/Kleinschreibung beachten",
+                    next: "Nächster Treffer",
+                    previous: "Vorheriger Treffer",
+                    close: "Schliessen",
+                    of: "von"
                 }
             }
         });

--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -675,62 +675,62 @@ $.extend(true, kendo.ui.ListBox.prototype.options.messages,{
   if (kendo.ui.PDFViewer) {
     kendo.ui.PDFViewer.prototype.options.messages =
         $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
-            defaultFileName: 'Mein Dokument',
+            defaultFileName: "Mein Dokument",
             toolbar: {
                 zoom: {
-                    zoomOut: 'Herauszoomen',
-                    zoomIn: 'Hineinzoomen',
-                    actualWidth: 'Tatsächliche Breite',
-                    autoWidth: 'Automatische Breite',
-                    fitToWidth: 'An Breite anpassen',
-                    fitToPage: 'An Seite anpassen'
+                    zoomOut: "Herauszoomen",
+                    zoomIn: "Hineinzoomen",
+                    actualWidth: "Tatsächliche Breite",
+                    autoWidth: "Automatische Breite",
+                    fitToWidth: "An Breite anpassen",
+                    fitToPage: "An Seite anpassen"
                 },
-                open: 'Öffnen',
-                exportAs: 'Exportieren',
-                download: 'Herunterladen',
+                open: "Öffnen",
+                exportAs: "Exportieren",
+                download: "Herunterladen",
                 pager: {
-                    first: 'Zur ersten Seite',
-                    previous: 'Zur vorherigen Seite',
-                    next: 'Zur nächsten Seite',
-                    last: 'Zur letzten Seite',
-                    of: ' von {0} ',
-                    page: 'Seite',
-                    pages: 'Seiten'
+                    first: "Zur ersten Seite",
+                    previous: "Zur vorherigen Seite",
+                    next: "Zur nächsten Seite",
+                    last: "Zur letzten Seite",
+                    of: " von {0} ",
+                    page: "Seite",
+                    pages: "Seiten"
                 },
-                print: 'Drucken',
-                toggleSelection: 'Markierungsmodus',
-                togglePan: 'Schwenkmodus',
-                search: 'Suchen'
+                print: "Drucken",
+                toggleSelection: "Markierungsmodus",
+                togglePan: "Schwenkmodus",
+                search: "Suchen"
             },
             errorMessages: {
-                notSupported: 'Dateityp nicht unterstützt.',
-                parseError: 'Fehler beim Verarbeiten der Datei.',
-                notFound: 'Datei konnte nicht gefunden werden.',
-                popupBlocked: 'Popups sind blockiert.'
+                notSupported: "Dateityp nicht unterstützt.",
+                parseError: "Fehler beim Verarbeiten der Datei.",
+                notFound: "Datei konnte nicht gefunden werden.",
+                popupBlocked: "Popups sind blockiert."
             },
             dialogs: {
                 exportAsDialog: {
-                    title: 'Exportieren...',
-                    defaultFileName: 'Dokument',
-                    pdf: 'Portable Document Format (.pdf)',
-                    png: 'Portable Network Graphics (.png)',
-                    svg: 'Scalable Vector Graphics (.svg)',
+                    title: "Exportieren...",
+                    defaultFileName: "Dokument",
+                    pdf: "Portable Document Format (.pdf)",
+                    png: "Portable Network Graphics (.png)",
+                    svg: "Scalable Vector Graphics (.svg)",
                     labels: {
-                        fileName: 'Dateiname',
-                        saveAsType: 'Speichern als',
-                        page: 'Seite'
+                        fileName: "Dateiname",
+                        saveAsType: "Speichern als",
+                        page: "Seite"
                     }
                 },
-                okText: 'OK',
-                save: 'Speichern',
-                cancel: 'Abbrechen',
+                okText: "OK",
+                save: "Speichern",
+                cancel: "Abbrechen",
                 search: {
-                    inputLabel: 'Suchtext',
-                    matchCase: 'Groß-/Kleinschreibung beachten',
-                    next: 'Nächster Treffer',
-                    previous: 'Vorheriger Treffer',
-                    close: 'Schließen',
-                    of: 'von'
+                    inputLabel: "Suchtext",
+                    matchCase: "Groß-/Kleinschreibung beachten",
+                    next: "Nächster Treffer",
+                    previous: "Vorheriger Treffer",
+                    close: "Schließen",
+                    of: "von"
                 }
             }
         });

--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -669,4 +669,71 @@ $.extend(true, kendo.ui.ListBox.prototype.options.messages,{
         "clearColor": "Farbe löschen"
     });
   }
+  
+  /* PDFViewer */
+  
+  if (kendo.ui.PDFViewer) {
+    kendo.ui.PDFViewer.prototype.options.messages =
+        $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
+            defaultFileName: 'Mein Dokument',
+            toolbar: {
+                zoom: {
+                    zoomOut: 'Herauszoomen',
+                    zoomIn: 'Hineinzoomen',
+                    actualWidth: 'Tatsächliche Breite',
+                    autoWidth: 'Automatische Breite',
+                    fitToWidth: 'An Breite anpassen',
+                    fitToPage: 'An Seite anpassen'
+                },
+                open: 'Öffnen',
+                exportAs: 'Exportieren',
+                download: 'Herunterladen',
+                pager: {
+                    first: 'Zur ersten Seite',
+                    previous: 'Zur vorherigen Seite',
+                    next: 'Zur nächsten Seite',
+                    last: 'Zur letzten Seite',
+                    of: ' von {0} ',
+                    page: 'Seite',
+                    pages: 'Seiten'
+                },
+                print: 'Drucken',
+                toggleSelection: 'Markierungsmodus',
+                togglePan: 'Schwenkmodus',
+                search: 'Suchen'
+            },
+            errorMessages: {
+                notSupported: 'Dateityp nicht unterstützt.',
+                parseError: 'Fehler beim Verarbeiten der Datei.',
+                notFound: 'Datei konnte nicht gefunden werden.',
+                popupBlocked: 'Popups sind blockiert.'
+            },
+            dialogs: {
+                exportAsDialog: {
+                    title: 'Exportieren...',
+                    defaultFileName: 'Dokument',
+                    pdf: 'Portable Document Format (.pdf)',
+                    png: 'Portable Network Graphics (.png)',
+                    svg: 'Scalable Vector Graphics (.svg)',
+                    labels: {
+                        fileName: 'Dateiname',
+                        saveAsType: 'Speichern als',
+                        page: 'Seite'
+                    }
+                },
+                okText: 'OK',
+                save: 'Speichern',
+                cancel: 'Abbrechen',
+                search: {
+                    inputLabel: 'Suchtext',
+                    matchCase: 'Groß-/Kleinschreibung beachten',
+                    next: 'Nächster Treffer',
+                    previous: 'Vorheriger Treffer',
+                    close: 'Schließen',
+                    of: 'von'
+                }
+            }
+        });
+  }
+  
 })(window.kendo.jQuery);

--- a/src/messages/kendo.messages.de-LI.js
+++ b/src/messages/kendo.messages.de-LI.js
@@ -557,5 +557,71 @@ $.extend(true, kendo.ui.Prompt.prototype.options.localization, {
   "cancel": "Abbrechen"
 });
 }
+  
+  /* PDFViewer */
+  
+  if (kendo.ui.PDFViewer) {
+    kendo.ui.PDFViewer.prototype.options.messages =
+        $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
+            defaultFileName: 'Mein Dokument',
+            toolbar: {
+                zoom: {
+                    zoomOut: 'Herauszoomen',
+                    zoomIn: 'Hineinzoomen',
+                    actualWidth: 'Tatsächliche Breite',
+                    autoWidth: 'Automatische Breite',
+                    fitToWidth: 'An Breite anpassen',
+                    fitToPage: 'An Seite anpassen'
+                },
+                open: 'Öffnen',
+                exportAs: 'Exportieren',
+                download: 'Herunterladen',
+                pager: {
+                    first: 'Zur ersten Seite',
+                    previous: 'Zur vorherigen Seite',
+                    next: 'Zur nächsten Seite',
+                    last: 'Zur letzten Seite',
+                    of: ' von {0} ',
+                    page: 'Seite',
+                    pages: 'Seiten'
+                },
+                print: 'Drucken',
+                toggleSelection: 'Markierungsmodus',
+                togglePan: 'Schwenkmodus',
+                search: 'Suchen'
+            },
+            errorMessages: {
+                notSupported: 'Dateityp nicht unterstützt.',
+                parseError: 'Fehler beim Verarbeiten der Datei.',
+                notFound: 'Datei konnte nicht gefunden werden.',
+                popupBlocked: 'Popups sind blockiert.'
+            },
+            dialogs: {
+                exportAsDialog: {
+                    title: 'Exportieren...',
+                    defaultFileName: 'Dokument',
+                    pdf: 'Portable Document Format (.pdf)',
+                    png: 'Portable Network Graphics (.png)',
+                    svg: 'Scalable Vector Graphics (.svg)',
+                    labels: {
+                        fileName: 'Dateiname',
+                        saveAsType: 'Speichern als',
+                        page: 'Seite'
+                    }
+                },
+                okText: 'OK',
+                save: 'Speichern',
+                cancel: 'Abbrechen',
+                search: {
+                    inputLabel: 'Suchtext',
+                    matchCase: 'Groß-/Kleinschreibung beachten',
+                    next: 'Nächster Treffer',
+                    previous: 'Vorheriger Treffer',
+                    close: 'Schließen',
+                    of: 'von'
+                }
+            }
+        });
+  }
 
 })(window.kendo.jQuery);

--- a/src/messages/kendo.messages.de-LI.js
+++ b/src/messages/kendo.messages.de-LI.js
@@ -563,62 +563,62 @@ $.extend(true, kendo.ui.Prompt.prototype.options.localization, {
   if (kendo.ui.PDFViewer) {
     kendo.ui.PDFViewer.prototype.options.messages =
         $.extend(true, kendo.ui.PDFViewer.prototype.options.messages, {
-            defaultFileName: 'Mein Dokument',
+            defaultFileName: "Mein Dokument",
             toolbar: {
                 zoom: {
-                    zoomOut: 'Herauszoomen',
-                    zoomIn: 'Hineinzoomen',
-                    actualWidth: 'Tatsächliche Breite',
-                    autoWidth: 'Automatische Breite',
-                    fitToWidth: 'An Breite anpassen',
-                    fitToPage: 'An Seite anpassen'
+                    zoomOut: "Herauszoomen",
+                    zoomIn: "Hineinzoomen",
+                    actualWidth: "Tatsächliche Breite",
+                    autoWidth: "Automatische Breite",
+                    fitToWidth: "An Breite anpassen",
+                    fitToPage: "An Seite anpassen"
                 },
-                open: 'Öffnen',
-                exportAs: 'Exportieren',
-                download: 'Herunterladen',
+                open: "Öffnen",
+                exportAs: "Exportieren",
+                download: "Herunterladen",
                 pager: {
-                    first: 'Zur ersten Seite',
-                    previous: 'Zur vorherigen Seite',
-                    next: 'Zur nächsten Seite',
-                    last: 'Zur letzten Seite',
-                    of: ' von {0} ',
-                    page: 'Seite',
-                    pages: 'Seiten'
+                    first: "Zur ersten Seite",
+                    previous: "Zur vorherigen Seite",
+                    next: "Zur nächsten Seite",
+                    last: "Zur letzten Seite",
+                    of: " von {0} ",
+                    page: "Seite",
+                    pages: "Seiten"
                 },
-                print: 'Drucken',
-                toggleSelection: 'Markierungsmodus',
-                togglePan: 'Schwenkmodus',
-                search: 'Suchen'
+                print: "Drucken",
+                toggleSelection: "Markierungsmodus",
+                togglePan: "Schwenkmodus",
+                search: "Suchen"
             },
             errorMessages: {
-                notSupported: 'Dateityp nicht unterstützt.',
-                parseError: 'Fehler beim Verarbeiten der Datei.',
-                notFound: 'Datei konnte nicht gefunden werden.',
-                popupBlocked: 'Popups sind blockiert.'
+                notSupported: "Dateityp nicht unterstützt.",
+                parseError: "Fehler beim Verarbeiten der Datei.",
+                notFound: "Datei konnte nicht gefunden werden.",
+                popupBlocked: "Popups sind blockiert."
             },
             dialogs: {
                 exportAsDialog: {
-                    title: 'Exportieren...',
-                    defaultFileName: 'Dokument',
-                    pdf: 'Portable Document Format (.pdf)',
-                    png: 'Portable Network Graphics (.png)',
-                    svg: 'Scalable Vector Graphics (.svg)',
+                    title: "Exportieren...",
+                    defaultFileName: "Dokument",
+                    pdf: "Portable Document Format (.pdf)",
+                    png: "Portable Network Graphics (.png)",
+                    svg: "Scalable Vector Graphics (.svg)",
                     labels: {
-                        fileName: 'Dateiname',
-                        saveAsType: 'Speichern als',
-                        page: 'Seite'
+                        fileName: "Dateiname",
+                        saveAsType: "Speichern als",
+                        page: "Seite"
                     }
                 },
-                okText: 'OK',
-                save: 'Speichern',
-                cancel: 'Abbrechen',
+                okText: "OK",
+                save: "Speichern",
+                cancel: "Abbrechen",
                 search: {
-                    inputLabel: 'Suchtext',
-                    matchCase: 'Groß-/Kleinschreibung beachten',
-                    next: 'Nächster Treffer',
-                    previous: 'Vorheriger Treffer',
-                    close: 'Schließen',
-                    of: 'von'
+                    inputLabel: "Suchtext",
+                    matchCase: "Groß-/Kleinschreibung beachten",
+                    next: "Nächster Treffer",
+                    previous: "Vorheriger Treffer",
+                    close: "Schließen",
+                    of: "von"
                 }
             }
         });


### PR DESCRIPTION
Why: German translation for PDFViewer in german culture files were missing.

What: I've added translation to all german culture files for PDFViewer.

How: Compared tools like MS Word, MS Excel etc. to provide well known and high quality translations of the specific fields for the PDFViewer. The structure of the PDFViewer was provided in the forum here: https://www.telerik.com/forums/pdf-viewer---custom-toolbar-with-tag-helper 