### PR TITLE
Fix broken link Markdown in tabs.md

### DIFF
--- a/docs-aspnet/html-helpers/navigation/tabstrip/tabs.md
+++ b/docs-aspnet/html-helpers/navigation/tabstrip/tabs.md
@@ -12,7 +12,7 @@ The TabStrip provides advanced options for configuring its tabs.
 
 ## Tabs Positioning
 
-The TabStrip API provides the `.TabPosition()`[/api/Kendo.Mvc.UI.Fluent/TabStripBuilder#tabpositionkendomvcuitabstriptabposition] configuration option that allows you to set the position of the tabs. You can position the tabs to the top, left, right or bottom of the TabStrip via the [`TabStripTabPosition`](/api/Kendo.Mvc.UI/TabStripTabPosition)
+The TabStrip API provides the [`TabPosition`](/api/Kendo.Mvc.UI.Fluent/TabStripBuilder#tabpositionkendomvcuitabstriptabposition) configuration option that allows you to set the position of the tabs. You can position the tabs to the top, left, right or bottom of the TabStrip via the [`TabStripTabPosition`](/api/Kendo.Mvc.UI/TabStripTabPosition)
 
 The following example demonstrates how to position the TabStrip tabs to the right:
 


### PR DESCRIPTION
The hyperlink for `TabPostion` in the Tabs Positioning section was broken, leaving the page showing the following text:

![image](https://user-images.githubusercontent.com/1028098/181733617-845e3650-c2d4-4cfa-8d5b-dca752feb63c.png)

This corrects the busted markup for that link so that it's actually rendered as a link.