### PR TITLE
The TagHelper code is not correct

### DIFF
--- a/docs-aspnet/html-helpers/navigation/breadcrumb/icons.md
+++ b/docs-aspnet/html-helpers/navigation/breadcrumb/icons.md
@@ -61,7 +61,7 @@ The following example demonstrates how to configure different icons.
     <kendo-breadcrumb name="breadcrumb"
                         delimiter-icon="line">
         <kendo-breadcrumb-items>
-            <kendo-breadcrumb-item type="BreadcrumbItemType.RootItem" text="All Components" href="https://demos.telerik.com/kendo-ui/" show-text="true" icon="globe" show-icon="true"></kendo-breadcrumb-items>
+            <kendo-breadcrumb-item type="BreadcrumbItemType.RootItem" text="All Components" href="https://demos.telerik.com/kendo-ui/" show-text="true" icon="globe" show-icon="true"></kendo-breadcrumb-item>
             <kendo-breadcrumb-item type="BreadcrumbItemType.Item" text="Breadcrumb" href="/breadcrumb" icon="gear" show-icon="true"></kendo-breadcrumb-item>
             <kendo-breadcrumb-item type="BreadcrumbItemType.Item" text="Tag Helper" href="/tag-helper" icon="cloud" show-icon="true"></kendo-breadcrumb-item>
         </kendo-breadcrumb-items>


### PR DESCRIPTION
There is a mix of a closing tag for the first item. Here is the corrected code:

```
<kendo-breadcrumb name="breadcrumb" delimiter-icon="line">
    <kendo-breadcrumb-items>
        <kendo-breadcrumb-item type="BreadcrumbItemType.RootItem" text="All Components" href="https://demos.telerik.com/kendo-ui/" show-text="true" icon="globe" show-icon="true"></kendo-breadcrumb-item>
        <kendo-breadcrumb-item type="BreadcrumbItemType.Item" text="Breadcrumb" href="/breadcrumb" icon="gear" show-icon="true"></kendo-breadcrumb-item>
        <kendo-breadcrumb-item type="BreadcrumbItemType.Item" text="Tag Helper" href="/tag-helper" icon="cloud" show-icon="true"></kendo-breadcrumb-item>
    </kendo-breadcrumb-items>
</kendo-breadcrumb>
```