### PR TITLE
Extra Indentation in OptionLabel Issue #6939

### DIFF
--- a/styles/web/Default/list/_layout.less
+++ b/styles/web/Default/list/_layout.less
@@ -100,7 +100,6 @@
 .k-list-item-text,
 .k-list-optionlabel {
     &::before {
-        content: "\200b";
         width: 0px;
         overflow: hidden;
     }


### PR DESCRIPTION
A pull request is being submitted for the Extra Indentation in OptionLabel issue submission located at the following URL:

https://github.com/telerik/kendo-ui-core/issues/6939

The k-list-optionlabel class has a styling of "content: "\200b";". If this indentation is not intended, this pull request removes this from the class styling to move it inline with the k-list-item's.