### PR TITLE
Adds missing `categories` property on `xAxis` and `yAxis` in Chart Options

### DIFF
--- a/typescript/kendo.all.d.ts
+++ b/typescript/kendo.all.d.ts
@@ -16439,6 +16439,7 @@ declare namespace kendo.dataviz.ui {
         axisCrossingValue?: any|Date|any | undefined;
         background?: string | undefined;
         baseUnit?: string | undefined;
+        categories?: any[] | undefined;
         color?: string | undefined;
         crosshair?: ChartXAxisItemCrosshair | undefined;
         labels?: ChartXAxisItemLabels | undefined;
@@ -16729,6 +16730,7 @@ declare namespace kendo.dataviz.ui {
         axisCrossingValue?: any|Date|any | undefined;
         background?: string | undefined;
         baseUnit?: string | undefined;
+        categories?: any[] | undefined;
         color?: string | undefined;
         crosshair?: ChartYAxisItemCrosshair | undefined;
         labels?: ChartYAxisItemLabels | undefined;


### PR DESCRIPTION
Added missing `categories` property on `xAxis` and `yAxis` in `ChartOptions`.