### PR TITLE
Lacks tagHelper version od markup

### DIFF
--- a/docs-aspnet/html-helpers/data-management/grid/binding/local.md
+++ b/docs-aspnet/html-helpers/data-management/grid/binding/local.md
@@ -77,6 +77,8 @@ To configure the Grid for {{ site.framework }} to do local binding:
             })
         )
     ```
+    ```TagHelper
+    ```
     
 1. Build and run the application.
 


### PR DESCRIPTION
There is no TagHelper version for a few markup samples here. Especially for local binding.