### PR TITLE
Fix icons-list.html

### DIFF
--- a/docs/styles-and-layout/sass-themes/icons-list.html
+++ b/docs/styles-and-layout/sass-themes/icons-list.html
@@ -277,7 +277,7 @@
             <li><span class="k-icon k-i-snap-grid"></span>.k-i-snap-grid</li>
             <li><span class="k-icon k-i-snap-to-gridlines"></span>.k-i-snap-to-gridlines</li>
             <li><span class="k-icon k-i-snap-to-snaplines"></span>.k-i-snap-to-snaplines</li>
-            <li><span class="k-icon k-i-dimentions"></span>.k-i-dimentions</li>
+            <li><span class="k-icon k-i-dimensions"></span>.k-i-dimensions</li>
             <li><span class="k-icon k-i-align-self-stretch"></span>.k-i-align-self-stretch</li>
             <li><span class="k-icon k-i-align-self-stretch-alt"></span>.k-i-align-self-stretch-alt</li>
             <li><span class="k-icon k-i-align-items-start"></span>.k-i-align-items-start</li>


### PR DESCRIPTION
Fixed typo: k-i-dimensions was written as k-i-dimentions in both class (making the icon invisible) and its description.