### PR TITLE
Add missing grid dv to alternating row template

### DIFF
--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -71,7 +71,7 @@ The [template](/api/javascript/kendo/methods/template) which renders the alterna
 > Set the `class` of the table row to `k-alt` to get the default "alternating" look and feel.
 
 #### Example - specify alternating row template
-
+    <div id="grid"></div>
     <script>
       let encode = kendo.htmlEncode;
       


### PR DESCRIPTION
The Grid altRowTemplate's example was missing the grid selector causing the preview for the example to not load.