### PR TITLE
Important information about kendo.ui.grid.saveAsExcel in grid.md

### DIFF
--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -10862,6 +10862,8 @@ The new column width.
 
 Initiates the Excel export. Also fires the [`excelExport`](/api/javascript/ui/grid/events/excelexport) event.
 
+> This call requires JSZip library included.
+	
 > Calling this method could trigger the browser built-in popup blocker in some cases. To avoid that, always call it as a response to an end-user action e.g. button click.
 
 #### Example - manually initiate Excel export


### PR DESCRIPTION
saveAsExcel doesn't do anything without jszip