### PR TITLE
Fixes typos in grid.md

### DIFF
--- a/docs/api/javascript/ui/grid.md
+++ b/docs/api/javascript/ui/grid.md
@@ -10676,7 +10676,7 @@ Hides the specified grid column.
 
 The index of the column, or the [field](/api/javascript/ui/grid/configuration/columns.field) to which the columns is bound, or the column object obtained from the [columns](/api/javascript/ui/grid/fields/columns) collection.
 
-When using multicolumn headers, using an index will hide a top-level column together will all its "child columns". In such scenarios, using field names or column objects may be more appropriate.
+When using multicolumn headers, using an index will hide a top-level column together with all its "child columns". In such scenarios, using field names or column objects may be more appropriate.
 
 #### Example - hide a column by index
 
@@ -11411,7 +11411,7 @@ Shows the specified column.
 
 The index of the column, or the [field](/api/javascript/ui/grid/configuration/columns.field) to which the columns is bound, or the column object obtained from the [columns](/api/javascript/ui/grid/fields/columns) collection.
 
-When using multicolumn headers, using an index will hide a top-level column together will all its "child columns". In such scenarios, using field names or column objects may be more appropriate.
+When using multicolumn headers, using an index will hide a top-level column together with all its "child columns". In such scenarios, using field names or column objects may be more appropriate.
 
 #### Example - show a hidden column by index
 


### PR DESCRIPTION
Fixed a typo occurring in 2 places in the grid docs.

On lines #10679 and #11414, this typo appears.
> using an index will hide a top-level column together **will** all its "child columns"

I believe it should be "with" not "will".
> using an index will hide a top-level column together **with** all its "child columns"