### PR TITLE
Update nuget-install.md

### DIFF
--- a/docs-aspnet/installation/nuget-install.md
+++ b/docs-aspnet/installation/nuget-install.md
@@ -11,7 +11,7 @@ position: 3
 
 This article describes how to configure your system for the Telerik NuGet source and then use it to install {{ site.product }} in your project. 
 
-[NuGet](https://www.nuget.org) is a popular .NET package manager. Telerik maintains a NuGet feed with official {{ site.product }} releases and service packs. These packages are available only for registered users with an active trial or commercial license. In the Telerik NuGet feed, you will see only the packages that are licensed to your account.
+[NuGet](https://www.nuget.org) is a popular .NET package manager. Telerik maintains a custom, private, NuGet feed with official {{ site.product }} releases and service packs. In the Telerik NuGet feed, you will see only the packages that are licensed to your account (for both current and previous releases).
 
 {% if site.core %}
 >tipLooking for a complete tutorial? Check out the [Getting Started guide that uses NuGet]({%slug gettingstarted_aspnetmvc6_aspnetmvc%}) to add Telerik UI to the project.

--- a/docs-aspnet/installation/nuget-install.md
+++ b/docs-aspnet/installation/nuget-install.md
@@ -11,7 +11,7 @@ position: 3
 
 This article describes how to configure your system for the Telerik NuGet source and then use it to install {{ site.product }} in your project. 
 
-[NuGet](https://www.nuget.org) is a popular .NET package manager. Telerik maintains a custom, private, NuGet feed with official {{ site.product }} releases and service packs. In the Telerik NuGet feed, you will see only the packages that are licensed to your account (for both current and previous releases).
+[NuGet](https://www.nuget.org) is a popular .NET package manager. Telerik maintains a private NuGet feed with official {{ site.product }} releases and service packs. In the Telerik NuGet feed, you will see packages that your account has a license for; trials (active) and commerical (active and expired).
 
 {% if site.core %}
 >tipLooking for a complete tutorial? Check out the [Getting Started guide that uses NuGet]({%slug gettingstarted_aspnetmvc6_aspnetmvc%}) to add Telerik UI to the project.


### PR DESCRIPTION
Updated the description of what NuGet packages a customer will see in their feed. Specifically clarified that a customer will still be able to see and restore packages for an older version they may not have a currently active commercial or trial license for.

e.g. A customer had a license in 2019 and a license during 2022 would see the following version in their NuGet feed even though they don't have a currently active license:

|  Version |
|----------|
| 2019.1.x | 
| 2019.2.x |
| 2019.3.x |
| 2022.1.x |
| 2022.2.x |
| 2022.3.x |

Note that I omitted service pack releases for brevity and simplicity. The important takeaway is this customer only has valid access to packages released in 2019 and packages released in 2022... the period of the commercial license.

## Update
After several tests, I can confirm our expectations are correct. A customer with only an expired license can still use the Telerik NuGet server for access to the older packages.



