### PR TITLE
Fix: TimePicker preview not working

### DIFF
--- a/docs/controls/timepicker/get-started.md
+++ b/docs/controls/timepicker/get-started.md
@@ -17,7 +17,7 @@ After the completion of this guide, you will be able to achieve the following en
 
     <script>
       // create TimePicker from input HTML element
-      $("#datetimepicker").kendoTimePicker({
+      $("#timepicker").kendoTimePicker({
         value: new Date(2023, 0, 1, 10, 30),
         min: new Date(2023, 0, 1, 8, 0, 0), //date part is ignored
         min: new Date(2023, 0, 1, 22, 0, 0), //date part is ignored


### PR DESCRIPTION
# Info
This PR solves a simple issue in the Documentation page for Kendo UI for jQuery.
In the TimePicker Getting Started page, when you preview the code, it's actually showing just an empty input field, not a TimePicker field.

# Issue
The issue is just that the jQuery selector is pointing to an element with an ID of `datetimepicker`, while the ID of the element in the preview is `timepicker`.

# Solution
Target the element correctly.