### PR TITLE
Updated example code for integration.md

### DIFF
--- a/docs/controls/loader/integration.md
+++ b/docs/controls/loader/integration.md
@@ -64,17 +64,20 @@ The following example demonstrates how the Loader can be used as a building bloc
     <script>
         var loadingPanelVisible = false;
         $("#loader").kendoLoader({
-        	visible:false
+            visible:false
         });
+      	$(".k-loading-panel").hide();
         $("button").click(function(){
           var loader = $("#loader").data("kendoLoader");
           loadingPanelVisible = !loadingPanelVisible;
           if (loadingPanelVisible) {
             $("button").text('Hide Loading Panel');
             loader.show();
+            $(".k-loading-panel").show();
           } else {
             $("button").text('Show Loading Panel');
             loader.hide();
+            $(".k-loading-panel").hide();
           }
         })
     </script>


### PR DESCRIPTION
https://docs.telerik.com/kendo-ui/controls/loader/integration > Loader in a Loading Panel example code updated

The example is slightly misleading because the button text says "Show/Hide Loading Panel", but when you click it it only shows/hides the loader component. Example code has been updates to also show/hide div.k-loading-panel