### PR TITLE
Update grid-add-a-custom-button-in-toolbar.md

### DIFF
--- a/docs-aspnet/knowledge-base/grid-add-a-custom-button-in-toolbar.md
+++ b/docs-aspnet/knowledge-base/grid-add-a-custom-button-in-toolbar.md
@@ -40,7 +40,7 @@ To add a custom button:
         .ToolBar(e => {
             e.Pdf();
             e.Excel();
-            e.Custom().Text("Instructions").HtmlAttributes(new { id = "customButton", @class="floatRight" });
+            e.Custom().Text("Instructions").HtmlAttributes(new { id = "customButton", @class="flexAlignRight" });
         })
     ```
 
@@ -58,8 +58,8 @@ To add a custom button:
 1. Finally, add some style to right align the {{ site.product }} Button.
 
     ```css
-        .floatRight {
-            float: right;
+        .flexAlignRight {
+            margin-left: auto;
         }
     ```
 


### PR DESCRIPTION
The custom button can't float right because the k-toolbar class display is set to flex.  I propose using margin-left: auto.

![image](https://github.com/telerik/kendo-ui-core/assets/15090986/2458296d-f4a5-44da-846a-60d77b8cb15c)

**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform