### PR TITLE
Updated expand method to display correct class

### DIFF
--- a/docs/api/javascript/ui/treeview.md
+++ b/docs/api/javascript/ui/treeview.md
@@ -947,7 +947,7 @@ The nodes that are to be expanded.
     treeview.expand(treeview.findByText("foo"));
 
     // expand all loaded items
-    treeview.expand(".k-item");
+    treeview.expand(".k-treeview-item");
     </script>
 
 ### expandPath


### PR DESCRIPTION
`.k-item` was used in earlier versions of Kendo jQuery. In latest version the class is replaced by `k-treeview-item` so .k-item example won't work.

**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform