### PR TITLE
Kendo UI core/german translations apply and reset

### DIFF
--- a/src/messages/kendo.messages.de-AT.js
+++ b/src/messages/kendo.messages.de-AT.js
@@ -142,6 +142,8 @@
   if (kendo.ui.ColumnMenu) {
     kendo.ui.ColumnMenu.prototype.options.messages =
       $.extend(true, kendo.ui.ColumnMenu.prototype.options.messages, {
+        "apply": "Übernehmen",
+        "reset": "Zurücksetzen",
         "columns": "Spalten",
         "sortAscending": "Aufsteigend sortieren",
         "sortDescending": "Absteigend sortieren",

--- a/src/messages/kendo.messages.de-CH.js
+++ b/src/messages/kendo.messages.de-CH.js
@@ -142,6 +142,8 @@
   if (kendo.ui.ColumnMenu) {
     kendo.ui.ColumnMenu.prototype.options.messages =
       $.extend(true, kendo.ui.ColumnMenu.prototype.options.messages, {
+        "apply": "Übernehmen",
+        "reset": "Zurücksetzen",
         "columns": "Spalten",
         "sortAscending": "Aufsteigend sortieren",
         "sortDescending": "Absteigend sortieren",

--- a/src/messages/kendo.messages.de-DE.js
+++ b/src/messages/kendo.messages.de-DE.js
@@ -146,6 +146,8 @@
   if (kendo.ui.ColumnMenu) {
     kendo.ui.ColumnMenu.prototype.options.messages =
       $.extend(true, kendo.ui.ColumnMenu.prototype.options.messages, {
+        "apply": "Übernehmen",
+        "reset": "Zurücksetzen",
         "columns": "Spalten",
         "sortAscending": "Aufsteigend sortieren",
         "sortDescending": "Absteigend sortieren",

--- a/src/messages/kendo.messages.de-LI.js
+++ b/src/messages/kendo.messages.de-LI.js
@@ -85,6 +85,8 @@ $.extend(true, kendo.ui.FilterMultiCheck.prototype.options.messages,{
 if (kendo.ui.ColumnMenu) {
 kendo.ui.ColumnMenu.prototype.options.messages =
 $.extend(true, kendo.ui.ColumnMenu.prototype.options.messages,{
+  "apply": "Übernehmen",
+  "reset": "Zurücksetzen",
   "columns": "Spalten",
   "sortAscending": "Aufsteigend sortieren",
   "sortDescending": "Absteigend sortieren",


### PR DESCRIPTION
**Problem**

The "Apply" and "Reset" button in the Column Menu of a Kendo UI grid are not translated into German.

**Proposed Solution**

Adding translations for the "Apply" and "Reset" buttons in the Column Menu of a Kendo UI grid, for the files kendo.messages.de-AT, kendo.messages.de-CH, kendo.messages.de-DE and kendo.messages.de-LI. 

**Description of the Solution**

Adding those translations will cause those buttons to get translated when the language is set to German.