### PR TITLE
Update notification.md

### DIFF
--- a/docs/api/javascript/ui/notification.md
+++ b/docs/api/javascript/ui/notification.md
@@ -442,7 +442,10 @@ of each member of the collection, returned by the `getNotifications()` method. I
 
         // remove the two messages from the DOM
         elements.each(function(){
-            $(this).parent().remove();
+            // $(this).parent().remove();
+	    // in new kendo versions, the notification is nested one <div> deeper
+     	    // removing the direct parent only, will lead to moving notifications as the space is still occupied
+	    $(this).parent().parent().remove(); 
         });
 
         messageCount++;


### PR DESCRIPTION
Notification is now nested one div deeper, hence we have to remove the parent of the parent to avoid moving notifications.

**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform