### PR TITLE
Update 'exec' editor.md to include link to editor tools documentation

### DIFF
--- a/docs/api/javascript/ui/editor.md
+++ b/docs/api/javascript/ui/editor.md
@@ -5062,6 +5062,8 @@ The parameters for the executed command.
 
 The arguments for commands that expect such
 
+> List of commands can be found here: [tools](/api/javascript/ui/editor#configuration-tools)
+
 #### Example
 
     <textarea id="editor"></textarea>


### PR DESCRIPTION
Added a blockquote section to guide towards the editor tools documentation. This needs to be obvious to someone reading the documentation. Probably all of those tools should even be listed under the exec page as well.

Please include obvious links to relevant documentation. Especially with something that absolutely requires knowing specific strings from another documentation page.

**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform