### PR TITLE
Update kendo.core.js

### DIFF
--- a/src/kendo.core.js
+++ b/src/kendo.core.js
@@ -1929,6 +1929,10 @@ function pad(number, digits, end) {
         var length;
         var tzoffset;
 
+        if(isEmpty(value)){
+            return null;
+        }
+
         if (value && value.indexOf("/D") === 0) {
             date = dateRegExp.exec(value);
             if (date) {


### PR DESCRIPTION
Added check that date value is an empty object and return null

**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform

This change fixes a bug which affects grids populated with DataTable object.

If a DateTime value is null, Kendo UI calls indexOf on empty object when parsing this value, causing an exception and the grid never loads.

Please check [issue 8095](https://github.com/telerik/kendo-ui-core/issues/8095) for details

