### PR TITLE
Preserve initial values when input widgets change type

### DIFF
--- a/src/kendo.autocomplete.js
+++ b/src/kendo.autocomplete.js
@@ -67,7 +67,7 @@ export const __meta__ = {
 
     var AutoComplete = List.extend({
         init: function(element, options) {
-            var that = this, wrapper, disabled;
+            var that = this, wrapper, disabled, initialValue;
 
             that.ns = ns;
             options = Array.isArray(options) ? { dataSource: options } : options;
@@ -88,7 +88,9 @@ export const __meta__ = {
             that._dataSource();
             that._ignoreCase();
 
+            initialValue = element.val();
             element[0].type = "text";
+            element.val(initialValue);
             wrapper = that.wrapper;
 
             that._popup();
@@ -915,4 +917,3 @@ export const __meta__ = {
     }]);
 })(window.kendo.jQuery);
 export default kendo;
-

--- a/src/kendo.dateinput.js
+++ b/src/kendo.dateinput.js
@@ -38,7 +38,8 @@ var __meta__ = {
 
     var DateInput = Widget.extend({
         init: function(element, options) {
-            var that = this;
+            var that = this,
+                initialValue;
 
             Widget.fn.init.call(that, element, options);
             element = that.element;
@@ -61,6 +62,8 @@ var __meta__ = {
             element.css({
                 height: element[0].style.height
             });
+
+            initialValue = that.options.value || element.val();
 
 
             that._validationIcon = $(kendo.ui.icon({ icon: "exclamation-circle", iconClass: "k-input-validation-icon k-hidden" })).insertAfter(element);
@@ -91,7 +94,7 @@ var __meta__ = {
             } else {
                 that.readonly(element.is("[readonly]"));
             }
-            that.value(that.options.value || element.val());
+            that.value(initialValue);
             if (!skipStyling) {
                 that._applyCssClasses();
             }
@@ -933,4 +936,3 @@ var __meta__ = {
 }
 
 })(window.kendo.jQuery);
-

--- a/src/kendo.datepicker.js
+++ b/src/kendo.datepicker.js
@@ -375,6 +375,8 @@ var __meta__ = {
 
             that._icon();
 
+            initialValue = options.value || element.val();
+
             try {
                 element[0].setAttribute("type", "text");
             } catch (e) {
@@ -400,11 +402,11 @@ var __meta__ = {
                 that.readonly(element.is("[readonly]"));
             }
 
-            initialValue = parse(options.value || that.element.val(), options.parseFormats, options.culture);
+            initialValue = parse(initialValue, options.parseFormats, options.culture) || initialValue;
 
             that._createDateInput(options);
 
-            that._old = that._update(initialValue || that.element.val());
+            that._old = that._update(initialValue);
             that._oldText = element.val();
             that._applyCssClasses();
 
@@ -936,4 +938,3 @@ var __meta__ = {
     ui.plugin(DatePicker);
 
 })(window.kendo.jQuery);
-

--- a/src/kendo.datetimepicker.js
+++ b/src/kendo.datetimepicker.js
@@ -121,6 +121,8 @@ var __meta__ = {
             that._reset();
             that._template();
 
+            initialValue = options.value || element.val();
+
             try {
                 element[0].setAttribute("type", "text");
             } catch (e) {
@@ -146,11 +148,11 @@ var __meta__ = {
                 that.readonly(element.is("[readonly]"));
             }
 
-            initialValue = parse(options.value || that.element.val(), options.parseFormats, options.culture);
+            initialValue = parse(initialValue, options.parseFormats, options.culture) || initialValue;
 
             that._createDateInput(options);
 
-            that._old = that._update(initialValue || that.element.val());
+            that._old = that._update(initialValue);
             that._oldText = element.val();
             that._applyCssClasses();
 
@@ -1250,4 +1252,3 @@ var __meta__ = {
     ui.plugin(DateTimePicker);
 
 })(window.kendo.jQuery);
-

--- a/src/kendo.numerictextbox.js
+++ b/src/kendo.numerictextbox.js
@@ -54,7 +54,7 @@ export const __meta__ = {
          init: function(element, options) {
              var that = this,
              isStep = options && options.step !== undefined,
-             min, max, step, value, disabled;
+             min, max, step, value, disabled, initialValue;
              var inputType;
 
              Widget.fn.init.call(that, element, options);
@@ -86,6 +86,7 @@ export const __meta__ = {
              that._initialOptions = extend({}, options);
 
              inputType = element.attr("type");
+             initialValue = element.val();
 
              that._reset();
              that._wrapper();
@@ -117,9 +118,9 @@ export const __meta__ = {
 
              if (value == NULL) {
                  if (inputType == "number") {
-                    value = parseFloat(element.val());
+                    value = parseFloat(initialValue);
                  } else {
-                     value = element.val();
+                     value = initialValue;
                  }
              }
 
@@ -1003,4 +1004,3 @@ export const __meta__ = {
     ui.plugin(NumericTextBox);
 })(window.kendo.jQuery);
 export default kendo;
-

--- a/src/kendo.timepicker.js
+++ b/src/kendo.timepicker.js
@@ -1267,7 +1267,7 @@ var __meta__ = {
 
     var TimePicker = Widget.extend({
         init: function(element, options) {
-            var that = this, ul, timeView, disabled;
+            var that = this, ul, timeView, disabled, initialValue;
 
             options = options || {};
             options.componentType = options.componentType || "classic";
@@ -1350,6 +1350,8 @@ var __meta__ = {
             that._icon();
             that._reset();
 
+            initialValue = options.value || element.val();
+
             try {
                 element[0].setAttribute("type", "text");
             } catch (e) {
@@ -1392,7 +1394,7 @@ var __meta__ = {
                     messages: options.messages.dateInput
                 });
             }
-            that._old = that._update(options.value || that.element.val());
+            that._old = that._update(initialValue);
             that._oldText = element.val();
             that._applyCssClasses();
 
@@ -2061,4 +2063,3 @@ var __meta__ = {
     ui.plugin(TimePicker);
 
 })(window.kendo.jQuery);
-

--- a/tests/unit/autocomplete/initialization.js
+++ b/tests/unit/autocomplete/initialization.js
@@ -17,6 +17,26 @@ describe("kendo.ui.AutoComplete initialization", function() {
         assert.isOk(input.data("kendoAutoComplete") instanceof AutoComplete);
     });
 
+    it("uses the initial element value before changing the input type", function() {
+        let dateInput = $("<input type='date' value='2026-05-07' />").appendTo(Mocha.fixture);
+        let typeValue = dateInput[0].type;
+
+        Object.defineProperty(dateInput[0], "type", {
+            get: function() {
+                return typeValue;
+            },
+            set: function(value) {
+                typeValue = value;
+                this.value = "";
+            }
+        });
+
+        let autocomplete = new AutoComplete(dateInput, []);
+
+        assert.equal(autocomplete.element.val(), "2026-05-07");
+        assert.equal(autocomplete._old, "2026-05-07");
+    });
+
     it("data source is initialized from options.dataSource when array is passed", function() {
         let data = [1, 2];
         let autocomplete = new AutoComplete(input, {

--- a/tests/unit/dateinput/initialization.js
+++ b/tests/unit/dateinput/initialization.js
@@ -1,0 +1,42 @@
+import '@progress/kendo-ui/src/kendo.dateinput.js';
+
+describe("kendo.ui.DateInput initialization", function() {
+    let DateInput = kendo.ui.DateInput;
+
+    afterEach(function() {
+        kendo.destroy(Mocha.fixture);
+    });
+
+    it("preserves initial date input value", function() {
+        let dateinput = new DateInput($("<input type='date' value='2026-05-07' />").appendTo(Mocha.fixture), {
+            format: "yyyy-MM-dd"
+        });
+
+        assert.equal(dateinput.element.val(), "2026-05-07");
+        assert.equal(dateinput.value().getFullYear(), 2026);
+        assert.equal(dateinput.value().getMonth(), 4);
+        assert.equal(dateinput.value().getDate(), 7);
+    });
+
+    it("uses the initial element value before changing the input type", function() {
+        let dateInput = $("<input type='date' value='2026-05-07' />").appendTo(Mocha.fixture);
+        let setAttribute = dateInput[0].setAttribute;
+
+        dateInput[0].setAttribute = function(name, value) {
+            setAttribute.call(this, name, value);
+
+            if (name === "type" && value === "text") {
+                this.value = "1970-01-01";
+            }
+        };
+
+        let dateinput = new DateInput(dateInput, {
+            format: "yyyy-MM-dd"
+        });
+
+        assert.equal(dateinput.element.val(), "2026-05-07");
+        assert.equal(dateinput.value().getFullYear(), 2026);
+        assert.equal(dateinput.value().getMonth(), 4);
+        assert.equal(dateinput.value().getDate(), 7);
+    });
+});

--- a/tests/unit/datepicker/initialization.js
+++ b/tests/unit/datepicker/initialization.js
@@ -1,0 +1,42 @@
+import '@progress/kendo-ui/src/kendo.datepicker.js';
+
+describe("kendo.ui.DatePicker initialization", function() {
+    let DatePicker = kendo.ui.DatePicker;
+
+    afterEach(function() {
+        kendo.destroy(Mocha.fixture);
+    });
+
+    it("preserves initial date input value", function() {
+        let datepicker = new DatePicker($("<input type='date' value='2026-05-07' />").appendTo(Mocha.fixture), {
+            format: "yyyy-MM-dd"
+        });
+
+        assert.equal(datepicker.element.val(), "2026-05-07");
+        assert.equal(datepicker.value().getFullYear(), 2026);
+        assert.equal(datepicker.value().getMonth(), 4);
+        assert.equal(datepicker.value().getDate(), 7);
+    });
+
+    it("uses the initial element value before changing the input type", function() {
+        let dateInput = $("<input type='date' value='2026-05-07' />").appendTo(Mocha.fixture);
+        let setAttribute = dateInput[0].setAttribute;
+
+        dateInput[0].setAttribute = function(name, value) {
+            setAttribute.call(this, name, value);
+
+            if (name === "type" && value === "text") {
+                this.value = "1970-01-01";
+            }
+        };
+
+        let datepicker = new DatePicker(dateInput, {
+            format: "yyyy-MM-dd"
+        });
+
+        assert.equal(datepicker.element.val(), "2026-05-07");
+        assert.equal(datepicker.value().getFullYear(), 2026);
+        assert.equal(datepicker.value().getMonth(), 4);
+        assert.equal(datepicker.value().getDate(), 7);
+    });
+});

--- a/tests/unit/datetimepicker/initialization.js
+++ b/tests/unit/datetimepicker/initialization.js
@@ -1,0 +1,46 @@
+import '@progress/kendo-ui/src/kendo.datetimepicker.js';
+
+describe("kendo.ui.DateTimePicker initialization", function() {
+    let DateTimePicker = kendo.ui.DateTimePicker;
+
+    afterEach(function() {
+        kendo.destroy(Mocha.fixture);
+    });
+
+    it("preserves initial datetime-local input value", function() {
+        let datetimepicker = new DateTimePicker($("<input type='datetime-local' value='2026-05-07T13:30' />").appendTo(Mocha.fixture), {
+            format: "yyyy-MM-ddTHH:mm"
+        });
+
+        assert.equal(datetimepicker.element.val(), "2026-05-07T13:30");
+        assert.equal(datetimepicker.value().getFullYear(), 2026);
+        assert.equal(datetimepicker.value().getMonth(), 4);
+        assert.equal(datetimepicker.value().getDate(), 7);
+        assert.equal(datetimepicker.value().getHours(), 13);
+        assert.equal(datetimepicker.value().getMinutes(), 30);
+    });
+
+    it("uses the initial element value before changing the input type", function() {
+        let dateTimeInput = $("<input type='datetime-local' value='2026-05-07T13:30' />").appendTo(Mocha.fixture);
+        let setAttribute = dateTimeInput[0].setAttribute;
+
+        dateTimeInput[0].setAttribute = function(name, value) {
+            setAttribute.call(this, name, value);
+
+            if (name === "type" && value === "text") {
+                this.value = "1970-01-01T00:00";
+            }
+        };
+
+        let datetimepicker = new DateTimePicker(dateTimeInput, {
+            format: "yyyy-MM-ddTHH:mm"
+        });
+
+        assert.equal(datetimepicker.element.val(), "2026-05-07T13:30");
+        assert.equal(datetimepicker.value().getFullYear(), 2026);
+        assert.equal(datetimepicker.value().getMonth(), 4);
+        assert.equal(datetimepicker.value().getDate(), 7);
+        assert.equal(datetimepicker.value().getHours(), 13);
+        assert.equal(datetimepicker.value().getMinutes(), 30);
+    });
+});

--- a/tests/unit/numerictextbox/initialization.js
+++ b/tests/unit/numerictextbox/initialization.js
@@ -89,6 +89,25 @@ describe("kendo.ui.NumericTextBox initialization", function() {
         assert.equal(textbox._text.val(), "12.00");
     });
 
+    it("uses the initial element value before changing the input type", function() {
+        let numberInput = $('<input type="number" value="13.5" />').appendTo(Mocha.fixture);
+        let setAttribute = numberInput[0].setAttribute;
+
+        numberInput[0].setAttribute = function(name, value) {
+            setAttribute.call(this, name, value);
+
+            if (name === "type" && value === "text") {
+                this.value = "0";
+            }
+        };
+
+        let textbox = new NumericTextBox(numberInput);
+
+        assert.equal(textbox.value(), 13.5);
+        assert.equal(textbox.element.val(), "13.5");
+        assert.equal(textbox._text.val(), "13.50");
+    });
+
     it("Bind change events", function() {
         let textbox = new NumericTextBox(input.val("12"), {
             change: function() { }

--- a/tests/unit/timepicker/initialization.js
+++ b/tests/unit/timepicker/initialization.js
@@ -1,0 +1,40 @@
+import '@progress/kendo-ui/src/kendo.timepicker.js';
+
+describe("kendo.ui.TimePicker initialization", function() {
+    let TimePicker = kendo.ui.TimePicker;
+
+    afterEach(function() {
+        kendo.destroy(Mocha.fixture);
+    });
+
+    it("preserves initial time input value with 24-hour format", function() {
+        let timepicker = new TimePicker($("<input type='time' value='13:30' />").appendTo(Mocha.fixture), {
+            format: "HH:mm"
+        });
+
+        assert.equal(timepicker.element.val(), "13:30");
+        assert.equal(timepicker.value().getHours(), 13);
+        assert.equal(timepicker.value().getMinutes(), 30);
+    });
+
+    it("uses the initial element value before changing the input type", function() {
+        let timeInput = $("<input type='time' value='13:30' />").appendTo(Mocha.fixture);
+        let setAttribute = timeInput[0].setAttribute;
+
+        timeInput[0].setAttribute = function(name, value) {
+            setAttribute.call(this, name, value);
+
+            if (name === "type" && value === "text") {
+                this.value = "00:00";
+            }
+        };
+
+        let timepicker = new TimePicker(timeInput, {
+            format: "HH:mm"
+        });
+
+        assert.equal(timepicker.element.val(), "13:30");
+        assert.equal(timepicker.value().getHours(), 13);
+        assert.equal(timepicker.value().getMinutes(), 30);
+    });
+});


### PR DESCRIPTION
**Note to external contributors** - make sure to sign our Contribution License Agreement (CLA) first:

https://docs.google.com/forms/d/e/1FAIpQLSduN9hHUJpnjr_KOGsmSM_yGO-KKKggCJhiaOlEOLig6_Wkbg/viewform

## Summary

Several input-based widgets can lose their initial value when initialization changes the underlying input type to text before reading the element value. With jQuery 4 and browser-normalized inputs such as time, date, datetime-local, or number, this can result in the widget initializing from a normalized fallback value instead of the original input value.

This preserves the initial element value before type mutation in the affected controls and uses that preserved value during initialization. The fix covers TimePicker, DateInput, DatePicker, DateTimePicker, NumericTextBox, and AutoComplete. Slider and RangeSlider were checked and left unchanged because they read initial numeric settings from attributes rather than the post-mutation element value.

Regression tests cover each affected control's initialization path and simulate the value mutation that can occur during type conversion.

Fixes: #8466
