### PR TITLE
Fix/8482 da dk filtermulticheck messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ src/.tern-port
 build/timezone-js
 ci
 playground
+/.vs

--- a/src/messages/kendo.messages.da-DK.js
+++ b/src/messages/kendo.messages.da-DK.js
@@ -77,7 +77,15 @@ $.extend(true, kendo.ui.FilterMenu.prototype.options.operators,{
 if (kendo.ui.FilterMultiCheck) {
 kendo.ui.FilterMultiCheck.prototype.options.messages =
 $.extend(true, kendo.ui.FilterMultiCheck.prototype.options.messages,{
-  "search": "Søg"
+  "checkAll": "Vælg alle",
+  "clearAll": "Ryd alle",
+  "clear": "Nulstil",
+  "filter": "Filter",
+  "search": "Søg",
+  "cancel": "Annuller",
+  "selectedItemsFormat": "{0} elementer valgt",
+  "done": "Udført",
+  "into": "i"
 });
 }
 


### PR DESCRIPTION
CLA has been submitted.

**Why:**
The da-DK messages file is missing 8 translations in the FilterMultiCheck block, causing the multi-checkbox filter UI to fall back to English for Danish users.

**What:**
Added the missing 8 keys to the FilterMultiCheck block in src/messages/kendo.messages.da-DK.js.

**How:**
The existing block only contained the search key. The remaining keys (checkAll, clearAll, clear, filter, cancel, selectedItemsFormat, done, into) were added with Danish translations, consistent with the existing terminology used elsewhere in the same file.

Fixes #8482